### PR TITLE
fix errors with unrendered end tags

### DIFF
--- a/R/to_dovetail.R
+++ b/R/to_dovetail.R
@@ -129,9 +129,6 @@ to_dovetail <- function(block, token = "#'") {
   txt <- gsub("\n\n```", "\n#' \n#' ```", txt)
   # fix closing code fenes
   txt <- gsub("\n```", "\n#' ```", txt)
-  # add challenge roxygen tag
-  # txt <- if (grepl("^#' ## ", txt)) sub("^#' ## ", '', txt) else paste0("\n", txt)
-  # txt <- glue::glue("{token} @{block_type} {txt}")
 
   # 8. rename the challenge node to be a code_block
   xml2::xml_set_name(block, "code_block")

--- a/inst/lesson-fragment/_episodes/12-for-loops.md
+++ b/inst/lesson-fragment/_episodes/12-for-loops.md
@@ -311,6 +311,10 @@ print(total)
 > > ~~~
 > > {: .language-python}
 > {: .solution}
+> 
+> ZNK: this is a test of text after an end block
+> 
+> ZNK: test two
 {: .challenge}
 
 > ## Cumulative Sum

--- a/inst/stylesheets/xml2md_roxy.xsl
+++ b/inst/stylesheets/xml2md_roxy.xsl
@@ -51,7 +51,8 @@ When there is a "xygen" tag, this adds the tag before the text like so:
     <!-- In all other cases, the node is processed normally -->
         <xsl:otherwise>
             <xsl:text>&#10;</xsl:text>
-            <xsl:apply-templates select="." mode="indent-block"/>
+            <xsl:apply-imports select="md:*" mode="indent"/>
+            <xsl:value-of select="@comment"/>
         </xsl:otherwise>
     </xsl:choose>
 </xsl:template>

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -207,12 +207,14 @@ test_that("challenges with multiple solution blocks will be rendered appropriate
   expect_true(xml2::xml_find_lgl(chlng, "boolean(self::d1:code_block)"))
   expect_match(xml2::xml_text(chlng), "## Practice Accumulating")
   expect_match(xml2::xml_text(chlng), "@solution Solution")
+  expect_match(xml2::xml_text(chlng), "ZNK: this is a test")
+  expect_match(xml2::xml_text(chlng), "ZNK: test two")
 
   # There will be four solution blocks and four challenge blocks
   ctxt <- strsplit(xml2::xml_text(chlng), "\n")[[1]]
   expect_equal(sum(grepl("@solution", ctxt)), 4)
   expect_equal(sum(grepl("@challenge", ctxt)), 0)
-  expect_equal(sum(grepl("@end", ctxt)), 3)
+  expect_equal(sum(grepl("@end", ctxt)), 4)
 
   # This process works for non-challenge blocks
   e$reset()
@@ -222,11 +224,13 @@ test_that("challenges with multiple solution blocks will be rendered appropriate
   expect_true(xml2::xml_find_lgl(chlng, "boolean(self::d1:code_block)"))
   expect_match(xml2::xml_text(chlng), "## Practice Accumulating")
   expect_match(xml2::xml_text(chlng), "@solution Solution")
+  expect_match(xml2::xml_text(chlng), "ZNK: this is a test")
+  expect_match(xml2::xml_text(chlng), "ZNK: test two")
   ctxt <- strsplit(xml2::xml_text(chlng), "\n")[[1]]
   expect_equal(sum(grepl("@solution", ctxt)), 4)
   expect_equal(sum(grepl("@challenge", ctxt)), 0)
   expect_equal(sum(grepl("@callout", ctxt)), 0)
-  expect_equal(sum(grepl("@end", ctxt)), 3)
+  expect_equal(sum(grepl("@end", ctxt)), 4)
 
   # This works if the first part is not a level2 heading
   e$reset()
@@ -238,11 +242,13 @@ test_that("challenges with multiple solution blocks will be rendered appropriate
   expect_true(xml2::xml_find_lgl(chlng, "boolean(self::d1:code_block)"))
   expect_match(xml2::xml_text(chlng), "### Practice Accumulating")
   expect_match(xml2::xml_text(chlng), "@solution Solution")
+  expect_match(xml2::xml_text(chlng), "ZNK: this is a test")
+  expect_match(xml2::xml_text(chlng), "ZNK: test two")
   ctxt <- strsplit(xml2::xml_text(chlng), "\n")[[1]]
   expect_equal(sum(grepl("@solution", ctxt)), 4)
   expect_equal(sum(grepl("@challenge", ctxt)), 0)
   expect_equal(sum(grepl("@callout", ctxt)), 0)
-  expect_equal(sum(grepl("@end", ctxt)), 3)
+  expect_equal(sum(grepl("@end", ctxt)), 4)
 
 
 })


### PR DESCRIPTION
There was an error where the text after @end tags would not be rendered because it was not being properly handed off. This patch fixes that and adds tests to ensure they stay fixed.

For example, a block written like this

```markdown
> # Challenge 1
>
> Some text
> 
> > # Solution 1
> > 
> > some other text
> > 
> {: .solution}
>
> Some final text
{: .challenge}
```

Would have been rendered without "Some final text". This change to the xsl code fixes it.

To be honest, I'm not exactly sure how all the attributes work in this case. The only thing that had the comment attribute was the paragraph, but all the text was subsequently commented even though I applied the imported markdown styles and not my own)