### PR TITLE
Add memory; update sandpaper generator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,9 @@ This version introduces conversions that work together and can be chained to
 convert an episode from the old Jekyll style to the new {sandpaper} style. 
 Things are still very much in development though.
 
-* Conversions for sandpaper and dovetail are clearly separated
+* conversions for sandpaper and dovetail are clearly separated
+* the Episode class understands what conversions have been performed with a
+  private logical vector that tracks changes.
 * pkgdown site is now built automatically from github actions
 
 ## NEW EPISODE METHODS
@@ -12,10 +14,12 @@ Things are still very much in development though.
 * `use_dovetail()` inserts a setup chunk at the top of the file
 * `use_sandpaper()` converts chunks from their liquid/kramdown syntax to the 
   commonmark or RMD syntax
-* `move_*()` methods gain a `dovetail` boolean argument to indicate if they
-  should generate a dovetail block or just a plain div block
+* `move_*()` will generate a dovetail block or just a plain div block depending
+  on whether or not `use_dovetail()` has been called.
 * `remove_output()` does what it says on the tin
 * `remove_error()` removes error code blocks
+* `$output` and `$error` can now grab output and error chunks that were converted
+  via `use_sandpaper()`
 
 # pegboard 0.0.0.9001
 

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -76,7 +76,11 @@ Episode <- R6::R6Class("Episode",
     #' If there is no setup chunk, one will be created. If there is a setup
     #' chunk, then the `source` and `knitr_fig_path` calls will be removed.
     use_dovetail = function() {
+      if (private$mutations['use_dovetail']) {
+        return(invisible(self))
+      }
       use_dovetail(self$body)
+      private$mutations['use_dovetail'] <- TRUE
       invisible(self)
     },
 
@@ -96,21 +100,37 @@ Episode <- R6::R6Class("Episode",
     #'
     #' @param rmd if `TRUE`, lessons will be converted to RMarkdown documents
     use_sandpaper = function(rmd = FALSE) {
+      if (rmd && private$mutations['use_sandpaper_rmd']) {
+        return(invisible(self))
+      }
+      if (!rmd && private$mutations['use_sandpaper_md']) {
+        return(invisible(self))
+      }
       use_sandpaper(self$body, rmd)
+      type <- if (rmd) 'use_sandpaper_rmd' else 'use_sandpaper_md'
+      private$mutations[type] <- TRUE
       invisible(self)
     },
 
     #' @description
     #' Remove error blocks
     remove_error = function() {
+      if (private$mutations['remove_error']) {
+        return(invisible(self))
+      }
       purrr::walk(self$error, xml2::xml_remove)
+      private$mutations['remove_error'] <- TRUE
       invisible(self)
     },
     
     #' @description
     #' Remove output blocks
     remove_output = function() {
+      if (private$mutations['remove_output']) {
+        return(invisible(self))
+      }
       purrr::walk(self$output, xml2::xml_remove)
+      private$mutations['remove_output'] <- TRUE
       invisible(self)
     },
     
@@ -119,9 +139,13 @@ Episode <- R6::R6Class("Episode",
     #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
     #' styling, otherwise, the will be div blocks. 
     move_objectives = function(dovetail = TRUE) {
+      if (private$mutations['move_objectives']) {
+        invisible(self)
+      }
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "objectives", dovetail)
       private$clear_yaml_item("objectives")
+      private$mutations['move_objectives'] <- TRUE
       invisible(self)
     },
     
@@ -130,9 +154,13 @@ Episode <- R6::R6Class("Episode",
     #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
     #' styling, otherwise, the will be div blocks. 
     move_keypoints = function(dovetail = TRUE) {
+      if (private$mutations['move_keypoints']) {
+        invisible(self)
+      }
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "keypoints", dovetail)
       private$clear_yaml_item("keypoints")
+      private$mutations['move_keypoints'] <- TRUE
       invisible(self)
     },
 
@@ -141,9 +169,13 @@ Episode <- R6::R6Class("Episode",
     #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
     #' styling, otherwise, the will be div blocks. 
     move_questions = function(dovetail = TRUE) {
+      if (private$mutations['move_questions']) {
+        invisible(self)
+      }
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "questions", dovetail)
       private$clear_yaml_item("questions")
+      private$mutations['move_questions'] <- TRUE
       invisible(self)
     },
 
@@ -226,6 +258,7 @@ Episode <- R6::R6Class("Episode",
     #' xml2::xml_text(scope$tags[1])
     reset = function() {
       self$initialize(self$path)
+      private$mutations <- private$mutations & FALSE
       return(invisible(self))
     },
 
@@ -238,7 +271,11 @@ Episode <- R6::R6Class("Episode",
     #' scope$body # a full document with block quotes and code blocks, etc
     #' scope$isolate_blocks()$body # only one challenge block_quote
     isolate_blocks = function() {
+      if (private$mutations['isolate_blocks']) {
+        return(invisible(self))
+      }
       isolate_kram_blocks(self$body)
+      private$mutations['isolate_blocks'] <- TRUE
       invisible(self)
     },
 
@@ -253,7 +290,11 @@ Episode <- R6::R6Class("Episode",
     #' loop$get_blocks() # no blocks
     #' loop$code # now there are two blocks with challenge tags
     unblock = function(token = "#'") {
+      if (private$mutations['unblock']) {
+        return(invisible(self))
+      }
       purrr::walk(self$get_blocks(), to_dovetail, token = token)
+      private$mutations['unblock'] <- TRUE
       invisible(self)
     },
 
@@ -337,12 +378,20 @@ Episode <- R6::R6Class("Episode",
 
     #' @field output \[`xml_nodeset`\] all the output blocks from the episode
     output = function() {
-      get_code(self$body, ".output")
+      if (any(private$mutations[c('use_sandpaper_md', 'use_sandpaper_rmd')])) {
+        self$code[which(xml2::xml_attr(self$code, "info") == "output")]
+      } else {
+        get_code(self$body, ".output")
+      }
     },
 
     #' @field error \[`xml_nodeset`\] all the error blocks from the episode
     error = function() {
-      get_code(self$body, ".error")
+      if (any(private$mutations[c('use_sandpaper_md', 'use_sandpaper_rmd')])) {
+        self$code[which(xml2::xml_attr(self$code, "info") == "error")]
+      } else {
+        get_code(self$body, ".error")
+      }
     },
 
     #' @field code \[`xml_nodeset`\] all the code blocks from the episode
@@ -366,9 +415,24 @@ Episode <- R6::R6Class("Episode",
       yml[[what]] <- NULL
       self$yaml <- c("---", strsplit(yaml::as.yaml(yml), "\n")[[1]], "---")
     },
+
     record_problem = function(x) {
       private$problems <- c(private$problems, x)
     },
+    mutations = c(
+      unblock           = FALSE,
+      use_dovetail      = FALSE,
+      use_sandpaper_md  = FALSE,
+      use_sandpaper_rmd = FALSE,
+      isolate_blocks    = FALSE,
+      move_keypoints    = FALSE,
+      move_questions    = FALSE,
+      move_objectives   = FALSE,
+      remove_error      = FALSE,
+      remove_output     = FALSE,
+      NULL
+    ),
+
     problems = list(),
 
     deep_clone = function(name, value) {

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -136,12 +136,11 @@ Episode <- R6::R6Class("Episode",
     
     #' @description 
     #' move the objectives yaml item to the body
-    #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
-    #' styling, otherwise, the will be div blocks. 
-    move_objectives = function(dovetail = TRUE) {
+    move_objectives = function() {
       if (private$mutations['move_objectives']) {
         invisible(self)
       }
+      dovetail <- private$mutations['use_dovetail']
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "objectives", dovetail)
       private$clear_yaml_item("objectives")
@@ -151,12 +150,11 @@ Episode <- R6::R6Class("Episode",
     
     #' @description 
     #' move the keypoints yaml item to the body
-    #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
-    #' styling, otherwise, the will be div blocks. 
-    move_keypoints = function(dovetail = TRUE) {
+    move_keypoints = function() {
       if (private$mutations['move_keypoints']) {
         invisible(self)
       }
+      dovetail <- private$mutations['use_dovetail']
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "keypoints", dovetail)
       private$clear_yaml_item("keypoints")
@@ -166,12 +164,11 @@ Episode <- R6::R6Class("Episode",
 
     #' @description 
     #' move the questions yaml item to the body
-    #' @param dovetail if `TRUE`, the items will be compatible with {dovetail}
-    #' styling, otherwise, the will be div blocks. 
-    move_questions = function(dovetail = TRUE) {
+    move_questions = function() {
       if (private$mutations['move_questions']) {
         invisible(self)
       }
+      dovetail <- private$mutations['use_dovetail']
       yml <- self$get_yaml()
       move_yaml(yml, self$body, "questions", dovetail)
       private$clear_yaml_item("questions")

--- a/R/liquid_to_commonmark.R
+++ b/R/liquid_to_commonmark.R
@@ -42,8 +42,12 @@ liquid_to_commonmark <- function(block, make_rmd = FALSE) {
     return(block)
   }
 
-  # all blocks will start with {: .language-")
-  lang     <- substring(lang, 14, nchar(lang) - 1L)
+  # if blocks will start with {: .language-, trim it out
+  # otherwise, trim the first five characters and ensure 
+  # that they are not processed as RMD blocks
+  start    <- if (grepl("language", lang, fixed = TRUE)) 14 else 5
+  lang     <- substring(lang, start, nchar(lang) - 1L)
+  make_rmd <- make_rmd && start == 14 
   new_info <- if (make_rmd) "{lang}-chunk-{pos}" else "{lang}{info}"
   info     <- if (all(is.na(info))) "" else paste(",", info)
 

--- a/R/move_yaml.R
+++ b/R/move_yaml.R
@@ -1,7 +1,9 @@
 move_yaml <- function(yaml, body, what = "questions", dovetail = TRUE) {
   ln        <- xml_list_chunk(yaml, what, dovetail = dovetail)
-  to_insert <- xml2::xml_child(ln)
+  to_insert <- xml2::xml_children(ln)
   where <- if (what == "keypoints") length(xml2::xml_children(body)) else 1L
-  xml_slip_in(body, to_insert, where)
+  for (i in rev(to_insert)) {
+    xml_slip_in(body, i, where)
+  }
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -123,7 +123,7 @@ xml_list_chunk <- function(yaml, what, dovetail = TRUE) {
 #' @noRd
 #' @keywords internal
 get_setup_chunk <- function(body) {
-  query <- ".//d1:code_block[contains(text(), '../bin/chunk-options.R')]"
+  query <- "./d1:code_block[1][@language='r' and @include='FALSE']"
   setup <- xml2::xml_find_first(body, query)
 
   # No setup chunk from Jekyll site

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -294,17 +294,9 @@ Remove output blocks
 \subsection{Method \code{move_objectives()}}{
 move the objectives yaml item to the body
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Episode$move_objectives(dovetail = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Episode$move_objectives()}\if{html}{\out{</div>}}
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{dovetail}}{if \code{TRUE}, the items will be compatible with {dovetail}
-styling, otherwise, the will be div blocks.}
-}
-\if{html}{\out{</div>}}
-}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-move_keypoints"></a>}}
@@ -312,17 +304,9 @@ styling, otherwise, the will be div blocks.}
 \subsection{Method \code{move_keypoints()}}{
 move the keypoints yaml item to the body
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Episode$move_keypoints(dovetail = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Episode$move_keypoints()}\if{html}{\out{</div>}}
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{dovetail}}{if \code{TRUE}, the items will be compatible with {dovetail}
-styling, otherwise, the will be div blocks.}
-}
-\if{html}{\out{</div>}}
-}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-move_questions"></a>}}
@@ -330,17 +314,9 @@ styling, otherwise, the will be div blocks.}
 \subsection{Method \code{move_questions()}}{
 move the questions yaml item to the body
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Episode$move_questions(dovetail = TRUE)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Episode$move_questions()}\if{html}{\out{</div>}}
 }
 
-\subsection{Arguments}{
-\if{html}{\out{<div class="arguments">}}
-\describe{
-\item{\code{dovetail}}{if \code{TRUE}, the items will be compatible with {dovetail}
-styling, otherwise, the will be div blocks.}
-}
-\if{html}{\out{</div>}}
-}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-get_challenge_graph"></a>}}

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -94,7 +94,7 @@ test_that("Episodes can be converted to use dovetail", {
 })
 
 
-test_that("Conversion pipeline works for rmarkdown sandpaper sites", {
+test_that("Integration: rmarkdown sandpaper sites", {
 
   loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
   e <- Episode$new(loop)
@@ -147,7 +147,7 @@ test_that("Conversion pipeline works for rmarkdown sandpaper sites", {
 
 })
 
-test_that("Conversion pipeline works for markdown sandpaper sites", {
+test_that("Integration: for markdown sandpaper sites", {
 
   loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
   e <- Episode$new(loop)
@@ -201,7 +201,61 @@ test_that("Conversion pipeline works for markdown sandpaper sites", {
 
 })
 
-test_that("Conversion pipeline works for jekyll sites", {
+test_that("Integration: for markdown sandpaper sites without dovetail", {
+
+  loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
+  e <- Episode$new(loop)
+  tags <- c(
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .language-python}",
+    "{: .language-python}"
+  )
+  expect_length(e$code, 11)
+  expect_length(e$challenges, 3)
+  expect_length(e$solutions, 3)
+  # 11 code blocks + 3 challenges + 3 solutions
+  expect_length(e$tags, 11 + 3 + 3)
+  expect_equal(xml2::xml_attr(e$code, "ktag"), tags)
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    "Use a for loop to process files given a list of their names."
+  )
+
+  e$
+    use_sandpaper(rmd = FALSE)$ # Ditch Jekyll, but keep markdown
+    unblock()$                  # Convert block quotes to code chunks
+    move_keypoints()$           # move yaml metadata to actual data
+    move_questions()$
+    move_objectives()
+
+  # The first child is not an RMD chunk
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    "Use a for loop to process files given a list of their names."
+  )
+  # NOTE: at the moment, we don't have a non-dovetail solution, but we're getting
+  # there!
+  expect_length(e$code, 11)
+  # python code chunks exist
+  expect_true(any(grepl("python", xml2::xml_attr(e$code, "info"))))
+  expect_true(any(grepl("output", xml2::xml_attr(e$code, "info"))))
+  # No kramdown tags exist
+  expect_length(e$tags, 0)
+  expect_match(
+    xml2::xml_text(xml2::xml_child(e$body, length(xml2::xml_children(e$body)))),
+    "</div>",
+    fixed = TRUE
+  )
+
+})
+
+test_that("Integration: jekyll sites", {
 
 
   loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -17,6 +17,7 @@ test_that("Episodes can be converted to use sandpaper", {
   )
   new_tags <- tags
   new_tags[grepl("python", tags)] <- NA
+  infos <- ifelse(grepl("python", tags), "python", "output")
   langs <- ifelse(grepl("python", tags), "python", NA)
 
   expect_length(e$code, 11)
@@ -24,7 +25,9 @@ test_that("Episodes can be converted to use sandpaper", {
   # With RMD -------------------------------------------------------------------
   expect_length(e$reset()$use_sandpaper(rmd = TRUE)$code, 12)
   # ktags are converted
-  expect_equal(xml2::xml_attr(e$code, "ktag"), c(NA, new_tags))
+  expect_equal(xml2::xml_attr(e$code, "ktag"), rep(NA_character_, 12)) 
+  # but the block quotes are still there
+  expect_length(e$tags, 3 + 3)
   # language tags added
   expect_equal(xml2::xml_attr(e$code, "language"), c("r", langs))
   # name tags added
@@ -33,19 +36,27 @@ test_that("Episodes can be converted to use sandpaper", {
   expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
     'library("reticulate")\n# Generated with {pegboard}'
   )
+  # output needs to be explicitly removed
+  expect_length(e$output, 4) 
+  expect_match(xml2::xml_attr(e$output, "info"), "output")
 
   # Without RMD ----------------------------------------------------------------
   expect_length(e$reset()$use_sandpaper(rmd = FALSE)$code, 11)
-  # ktags are converted
-  expect_equal(xml2::xml_attr(e$code, "ktag"), new_tags)
   # language tags added
-  expect_equal(xml2::xml_attr(e$code, "info"), langs)
+  expect_equal(xml2::xml_attr(e$code, "info"), infos)
+  # ktags are converted
+  expect_equal(xml2::xml_attr(e$code, "ktag"), rep(NA_character_, 11))
+  # but the block quotes are still there
+  expect_length(e$tags, 3 + 3)
   expect_equal(xml2::xml_attr(e$code, "name"), rep(NA_character_, 11))
   expect_equal(xml2::xml_attr(e$code, "language"), rep(NA_character_, 11))
   # First node is text
   expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
     "Use a for loop to process files given a list of their names."
   )
+  # output needs to be explicitly removed
+  expect_length(e$output, 4) 
+  expect_match(xml2::xml_attr(e$output, "info"), "output")
 
 })
 
@@ -83,8 +94,7 @@ test_that("Episodes can be converted to use dovetail", {
 })
 
 
-test_that("Conversion pipeline works", {
-
+test_that("Conversion pipeline works for rmarkdown sandpaper sites", {
 
   loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
   e <- Episode$new(loop)
@@ -103,6 +113,9 @@ test_that("Conversion pipeline works", {
   )
   expect_length(e$code, 11)
   expect_length(e$challenges, 3)
+  expect_length(e$solutions, 3)
+  # 11 code blocks + 3 challenges + 3 solutions
+  expect_length(e$tags, 11 + 3 + 3)
   expect_equal(xml2::xml_attr(e$code, "ktag"), tags)
   expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
     "Use a for loop to process files given a list of their names."
@@ -125,9 +138,124 @@ test_that("Conversion pipeline works", {
   # Note: the last three python chunks were inside of challenges. Calculation
   # original code chunks + yaml + setup - output
   expect_length(e$code, 11 + 3 + 1 - 4)
+  # No kramdown tags exist
+  expect_length(e$tags, 0)
   expect_equal(
     xml2::xml_attr(xml2::xml_child(e$body, length(xml2::xml_children(e$body))), "info"),
     "{keypoints}"
   )
+
+})
+
+test_that("Conversion pipeline works for markdown sandpaper sites", {
+
+  loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
+  e <- Episode$new(loop)
+  tags <- c(
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .language-python}",
+    "{: .language-python}"
+  )
+  expect_length(e$code, 11)
+  expect_length(e$challenges, 3)
+  expect_length(e$solutions, 3)
+  # 11 code blocks + 3 challenges + 3 solutions
+  expect_length(e$tags, 11 + 3 + 3)
+  expect_equal(xml2::xml_attr(e$code, "ktag"), tags)
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    "Use a for loop to process files given a list of their names."
+  )
+
+  # Conversion chain!!!!
+  e$
+    use_dovetail()$             # Convert to dovetail
+    use_sandpaper(rmd = FALSE)$ # Ditch Jekyll, but keep markdown
+    unblock()$                  # Convert block quotes to code chunks
+    move_keypoints()$           # move yaml metadata to actual data
+    move_questions()$
+    move_objectives()
+
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    'library("dovetail")\n# Generated with {pegboard}'
+  )
+  # Note: the last three python chunks were inside of challenges. Calculation
+  # original code chunks + yaml + setup - output
+  expect_length(e$code, 11 + 3 + 1)
+  # python code chunks exist
+  expect_true(any(grepl("python", xml2::xml_attr(e$code, "info"))))
+  expect_true(any(grepl("output", xml2::xml_attr(e$code, "info"))))
+  # No kramdown tags exist
+  expect_length(e$tags, 0)
+  expect_equal(
+    xml2::xml_attr(xml2::xml_child(e$body, length(xml2::xml_children(e$body))), "info"),
+    "{keypoints}"
+  )
+
+})
+
+test_that("Conversion pipeline works for jekyll sites", {
+
+
+  loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
+  e <- Episode$new(loop)
+  tags <- c(
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .output}",
+    "{: .language-python}",
+    "{: .language-python}",
+    "{: .language-python}"
+  )
+  expect_length(e$code, 11)
+  expect_length(e$challenges, 3)
+  expect_length(e$solutions, 3)
+  # 11 code blocks + 3 challenges + 3 solutions
+  expect_length(e$tags, 11 + 3 + 3)
+  expect_equal(xml2::xml_attr(e$code, "ktag"), tags)
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    "Use a for loop to process files given a list of their names."
+  )
+
+  # Conversion chain!!!!
+  e$
+    use_dovetail()$            # Convert to dovetail
+    unblock()$                 # Convert block quotes to code chunks
+    move_keypoints()$          # move yaml metadata to actual data
+    move_questions()$
+    move_objectives()
+
+  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+    'library("dovetail")\nsource(dvt_opts())\nknitr_fig_path("fig-")\n# Generated with {pegboard}'
+  )
+  # Note: the last three python chunks were inside of challenges. Calculation
+  # original code chunks + yaml + setup
+  expect_length(e$code, 11 + 3 + 1)
+  # kramdown/liquid tags still exist (three python chunks are inside challenges)
+  expect_length(e$tags, 11 - 3) 
+  expect_equal(xml2::xml_attr(xml2::xml_parent(e$tags), "ktag"), tags[1:8])
+
+  # Note: the last three python chunks were inside of challenges. Calculation
+  # original code chunks + yaml + setup - output
+  expect_equal(
+    xml2::xml_attr(xml2::xml_child(e$body, length(xml2::xml_children(e$body))), "info"),
+    "{keypoints}"
+  )
+  # output needs to be explicitly removed
+  expect_length(e$output, 4) 
+  expect_match(xml2::xml_attr(e$output, "ktag"), "{: .output}", fixed = TRUE)
+
 
 })


### PR DESCRIPTION
This PR adds a new private element called "mutations" that will keep track of the changes to the Episode. 

Other updates:

 - `$use_sandpaper()` will banish the liquid/kramdown tags in favor of the info tags
 - `$move_*()` functions drop the dovetail parameter because they can now check if it's been called.
 - `$output` and `$error` methods are now aware of their conversions. 