### PR TITLE
add label_divs() and questions methods

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pegboard 0.0.0.9006
+
+ - `$label_divs()` method now will label any div tags in the episode
+ - `$move_*` methods will now auto-label div tags
+ - `$questions` field now returns the questions block or yaml header as a
+   character vector.
+
 # pegboard 0.0.0.9005
 
  - pandoc-style fenced divs are now processed the same as native div tags

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -398,6 +398,8 @@ Episode <- R6::R6Class("Episode",
         ns <- NS(self$body)
         xpath <- glue::glue(".//{ns}:code_block[@info='{{questions}}' or @language='questions']")
         q <- xml2::xml_find_first(self$body, xpath)
+      } else {
+        return(q)
       }
       # If they produce something, parse, otherwise, try the divs
       if (length(q) > 0) {
@@ -405,7 +407,7 @@ Episode <- R6::R6Class("Episode",
         txt <- trimws(gsub("\n{2,}", "\n", txt, perl = TRUE))
         q <- strsplit(txt, "\n")[[1]]
       } else {
-        q <- xml2::xml_children(get_divs(self$body, "questions")[[1]])
+        q <- xml2::xml_children(get_divs(self$label_divs()$body, "questions")[[1]])
         q <- purrr::map_chr(q, xml2::xml_text)
       }
       return(trimws(q))

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -56,6 +56,14 @@ Episode <- R6::R6Class("Episode",
     },
 
     #' @description
+    #' label all the div elements within the Episode to extract them with 
+    #' `$get_divs()`
+    label_divs = function() {
+      label_div_tags(self$body)
+      return(invisible(self))
+    },
+    
+    #' @description
     #' return all div elements within the Episode
     #' @param type the type of div tag (e.g. 'challenge' or 'solution')
     get_divs = function(type = NULL) {
@@ -375,6 +383,24 @@ Episode <- R6::R6Class("Episode",
       xml2::xml_find_all(self$body, ".//@ktag")
     },
 
+    #' @field questions \[`character`\] the questions from the episode
+    questions = function() {
+      if (!private$mutations['move_questions']) {
+        yaml <- self$get_yaml()
+        return(trimws(yaml$questions))
+      } else if (private$mutations['use_dovetail']) {
+        ns <- NS(self$body)
+        xpath <- glue::glue(".//{ns}:code_block[@info='{{questions}}' or @language='questions']")
+        q <- xml2::xml_find_first(self$body, xpath)
+        txt <- gsub("\n?#' ?-?", "\n", xml2::xml_text(q), perl = TRUE)
+        txt <- trimws(gsub("\n{2,}", "\n", txt, perl = TRUE))
+        return(trimws(strsplit(txt, "\n")[[1]]))
+      } else {
+        q <- xml2::xml_children(get_divs(self$body, "questions")[[1]])
+        return(trimws(purrr::map_chr(q, xml2::xml_text)))
+      }
+    },
+
     #' @field challenges \[`xml_nodeset`\] all the challenges blocks from the episode
     challenges = function() {
       if (!private$mutations['unblock']) {
@@ -443,16 +469,16 @@ Episode <- R6::R6Class("Episode",
       private$problems <- c(private$problems, x)
     },
     mutations = c(
-      unblock           = FALSE,
-      use_dovetail      = FALSE,
-      use_sandpaper_md  = FALSE,
-      use_sandpaper_rmd = FALSE,
-      isolate_blocks    = FALSE,
-      move_keypoints    = FALSE,
-      move_questions    = FALSE,
-      move_objectives   = FALSE,
-      remove_error      = FALSE,
-      remove_output     = FALSE,
+      unblock           = FALSE, # have kramdown blocks been converted?
+      use_dovetail      = FALSE, # are we keeping challenges in code blocks?
+      use_sandpaper_md  = FALSE, # are we using a sandpaper lesson? 
+      use_sandpaper_rmd = FALSE, #   e.g. code has label, not liquid tag
+      isolate_blocks    = FALSE, # does our lesson consist of only blocks?
+      move_keypoints    = FALSE, # are the keypoints in the body?
+      move_questions    = FALSE, # are the questions in the body?
+      move_objectives   = FALSE, # are the objectives in the body?
+      remove_error      = FALSE, # have errors been removed?
+      remove_output     = FALSE, # have output been removed?
       NULL
     ),
 

--- a/R/move_yaml.R
+++ b/R/move_yaml.R
@@ -1,10 +1,11 @@
 move_yaml <- function(yaml, body, what = "questions", dovetail = TRUE) {
   ln        <- xml_list_chunk(yaml, what, dovetail = dovetail)
   to_insert <- xml2::xml_children(ln)
-  xml2::xml_set_attr(to_insert, "dtag", what)
+  # xml2::xml_set_attr(to_insert, "dtag", what)
   where <- if (what == "keypoints") length(xml2::xml_children(body)) else 1L
   for (i in rev(to_insert)) {
     xml_slip_in(body, i, where)
   }
+  label_div_tags(body)
 }
 

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -116,6 +116,8 @@ scope$challenges
 
 \item{\code{tags}}{[\code{xml_nodeset}] all the kramdown tags from the episode}
 
+\item{\code{questions}}{[\code{character}] the questions from the episode}
+
 \item{\code{challenges}}{[\code{xml_nodeset}] all the challenges blocks from the episode}
 
 \item{\code{solutions}}{[\code{xml_nodeset}] all the solutions blocks from the episode}
@@ -136,6 +138,7 @@ scope$challenges
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-get_blocks}{\code{Episode$get_blocks()}}
+\item \href{#method-label_divs}{\code{Episode$label_divs()}}
 \item \href{#method-get_divs}{\code{Episode$get_divs()}}
 \item \href{#method-get_yaml}{\code{Episode$get_yaml()}}
 \item \href{#method-use_dovetail}{\code{Episode$use_dovetail()}}
@@ -205,6 +208,17 @@ scope$get_blocks(".solution", level = 2)
 }
 \if{html}{\out{</div>}}
 
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-label_divs"></a>}}
+\if{latex}{\out{\hypertarget{method-label_divs}{}}}
+\subsection{Method \code{label_divs()}}{
+label all the div elements within the Episode to extract them with
+\verb{$get_divs()}
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Episode$label_divs()}\if{html}{\out{</div>}}
 }
 
 }

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -209,7 +209,7 @@ test_that("yaml items can be moved to the text (no dovetail)", {
   yml <- e$get_yaml()
   expect_named(yml, c("title", "teaching", "exercises", "keypoints"))
 
-  e$move_keypoints()
+  e$move_keypoints()$label_divs()
   expect_equal(length(e$get_divs()), 3)
   expect_equal(n_code_blocks, length(e$code))
   expect_length(xml2::xml_find_all(e$body, ".//d1:html_block"), 2 + 2 + 2 + 2)
@@ -448,6 +448,19 @@ test_that("dovetail with multiple solution blocks will be rendered appropriately
 
 })
 
+
+test_that("questions can be retrieved reliably from any source", {
+
+  scope <- fs::path(lesson_fragment(), "_episodes", "17-scope.md")
+  e <- Episode$new(scope)
+  answers <- c("How do function calls actually work?", 
+    "How can I determine where errors occurred?")
+  expect_equal(e$questions, answers)
+  expect_equal(e$move_questions()$questions, answers)
+  e <- Episode$new(scope)
+  expect_equal(e$use_dovetail()$move_questions()$questions, answers)
+
+})
 
 test_that("An episode can be cloned deeply", {
 


### PR DESCRIPTION
Because {sandpaper} needs access to the questions and these questions could be in one of three places, I'm adding an accessor. Moreover, I'm adding the div labeller to the methods because it will be easier for the user to do that themselves.

