### PR TITLE
update URI and list block handling

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9009
+Version: 0.0.0.9010
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# pegboard 0.0.0.9010
+
+ - Missing questions, objectives, or keypoints will no longer fail with a 
+   cryptic error. An informative warning will be thrown and an empty character
+   vector will be returned. This addresses an issue in {sandpaper}:
+   https://github.com/carpentries/sandpaper/issues/79
+ - The URI for pegboard tags is now "http://carpentries.org/pegboard/", which
+   fixes https://github.com/carpentries/pegboard/issues/18
+
 # pegboard 0.0.0.9009
 
  - Several Bug fixes, see https://github.com/carpentries/pegboard/pull/21 for

--- a/R/div.R
+++ b/R/div.R
@@ -98,7 +98,7 @@ replace_with_div <- function(block) {
 #' pegboard:::get_divs(loop$body, 'solution') # all solution blocks
 get_divs <- function(body, type = NULL){
   ns    <- get_ns(body)
-  if (!any(ns == "pegboard")) {
+  if (!any(ns == "http://carpentries.org/pegboard/")) {
     return(list())
   }
   # 1. Find tags
@@ -250,7 +250,7 @@ find_div_tags <- function(body) {
 #' @rdname div_labels
 clear_div_labels <- function(body) {
   ns <- get_ns(body)
-  if (!any(ns == "pegboard")) return(invisible(NULL))
+  if (!any(ns == "http://carpentries.org/pegboard/")) return(invisible(NULL))
   dtags <- xml2::xml_find_all(body, ".//pb:dtag", get_ns(body))
   purrr::walk(dtags, xml2::xml_remove)
 }
@@ -359,6 +359,7 @@ make_div_table <- function(nodes) {
 
 #' Add a pegboard node before or after a node
 #' 
+#' These nodes have the namespace of "http://carpentries.org/pegboard/"
 #' @keywords internal
 #' @param node a single node
 #' @param df a data frame generated from [make_div_table()]
@@ -373,7 +374,7 @@ add_pegboard_nodes <- function(node, df) {
       node,
       "dtag",
       label = df$label[i],
-      xmlns = "pegboard", 
+      xmlns = "http://carpentries.org/pegboard/", 
       .where = df$pos[i]
     )
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -37,7 +37,7 @@ NS <- function(x, generic = TRUE) {
 get_ns <- function(body) {
   ns <- xml2::xml_ns(body)
   # assuming that the first namespace is commonmark
-  ns   <- c(ns[1], ns[ns == "pegboard"][1])
+  ns   <- c(ns[1], ns[ns == "http://carpentries.org/pegboard/"][1])
   ns[] <- c("md", "pb")
   ns   <- as.list(ns[!is.na(names(ns))])
   xml2::xml_ns_rename(xml2::xml_ns(body), ns)

--- a/tests/testthat/test-get_list_block.R
+++ b/tests/testthat/test-get_list_block.R
@@ -1,0 +1,27 @@
+scope <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
+e     <- Episode$new(scope)
+withr::defer(rm(e, scope))
+
+test_that("get_list_block can fetch the YAML questions", {
+ 
+  yml <- e$get_yaml()
+  expect_equal(e$questions, yml[["questions"]])
+  expect_equal(get_list_block(e, "questions", in_yaml = TRUE), yml[["questions"]])
+
+})
+
+test_that("get_list_block will throw a warning for unexpected types", {
+ 
+  expect_warning(
+    res <- get_list_block(e, "questions", in_yaml = FALSE),
+    glue::glue("No section called {sQuote('questions')}")
+  )
+  expect_equal(res, character(0))
+
+  expect_warning(
+    res <- get_list_block(e, "hotdogs", in_yaml = FALSE),
+    glue::glue("No section called {sQuote('hotdogs')}")
+  )
+  expect_equal(res, character(0))
+
+})


### PR DESCRIPTION
 - Missing questions, objectives, or keypoints will no longer fail with a 
   cryptic error. An informative warning will be thrown and an empty character
   vector will be returned. This addresses an issue in {sandpaper}:
   https://github.com/carpentries/sandpaper/issues/79
 - The URI for pegboard tags is now "http://carpentries.org/pegboard/", which
   fixes https://github.com/carpentries/pegboard/issues/18

This will fix #18 