### PR TITLE
swap git2r for gert; bump version

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -54,6 +54,10 @@ jobs:
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
           restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
 
+      - name: Install Mac deps
+        if: runner.os == 'macOS'
+        run: brew install libgit2
+
       - name: Install system dependencies
         if: runner.os == 'Linux'
         run: |
@@ -61,6 +65,7 @@ jobs:
           do
             eval sudo $cmd
           done < <(Rscript -e 'writeLines(remotes::system_requirements("ubuntu", "20.04"))')
+          sudo apt install libgit2-dev
       - name: Install dependencies
         run: |
           remotes::install_deps(dependencies = TRUE)

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -16,6 +16,9 @@ jobs:
 
       - uses: r-lib/actions/setup-pandoc@master
 
+      - name: Install Mac deps
+        run: brew install libgit2
+
       - name: Query dependencies
         run: |
           install.packages('remotes')

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9010
+Version: 0.0.0.9011
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -17,7 +17,7 @@ Description: The Carpentries (https://carpentries.org>) curricula is made of of
 License: MIT + file LICENSE
 Imports:
     fs,
-    git2r,
+    gert (>= 1.0.0),
     tinkr,
     xml2,
     purrr,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -7,7 +7,7 @@ Authors@R:
            role = c("aut", "cre"),
            email = "zkamvar@gmail.com",
            comment = c(ORCID = "0000-0003-1458-7108"))
-Description: The Carpentries (https://carpentries.org>) curricula is made of of
+Description: The Carpentries (<https://carpentries.org>) curricula is made of of
     lessons that are hosted as websites. Each lesson represents between a half
     day to two days of instruction and contains several episodes, which are
     written as 'kramdown'-flavored 'markdown' documents and converted to HTML

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Description: The Carpentries (https://carpentries.org>) curricula is made of of
 License: MIT + file LICENSE
 Imports:
     fs,
-    gert (>= 1.0.0),
     tinkr,
     xml2,
     purrr,
@@ -28,6 +27,7 @@ Imports:
     yaml,
     commonmark
 Suggests:
+    gert (>= 1.0.0),
     testthat,
     withr,
     covr,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# pegboard 0.0.0.9011
+
+ - Swap {git2r} dependency for {gert}, which has a smoother interface and matches
+   with the dependencies of {sandpaper}.
+
 # pegboard 0.0.0.9010
 
  - Missing questions, objectives, or keypoints will no longer fail with a 

--- a/R/get_lesson.R
+++ b/R/get_lesson.R
@@ -18,6 +18,9 @@
 #' png <- get_lesson("swcarpentry/python-novice-gapminder")
 #' str(png, max.level = 1)
 get_lesson <- function(lesson = NULL, path = tempdir(), overwrite = FALSE, ...) {
+  if (!requireNamespace("gert", quietly = FALSE)) {
+    stop("Please install the {gert} package to use this feature.")
+  }
   if (is.null(lesson) && fs::dir_exists(fs::path(path, "_episodes"))) {
     # user provides path to lesson on computer
     the_path <- normalizePath(path)

--- a/R/get_lesson.R
+++ b/R/get_lesson.R
@@ -42,9 +42,10 @@ get_lesson <- function(lesson = NULL, path = tempdir(), overwrite = FALSE, ...) 
   episodes_rmd <- fs::path(the_path, "_episodes_rmd")
 
   if (!fs::dir_exists(episodes) && !fs::dir_exists(episodes_rmd)) {
-    lpath <- git2r::clone(
-      glue::glue("https://github.com/{lesson}.git"),
-      local_path = the_path
+    lpath <- gert::git_clone(
+      url = glue::glue("https://github.com/{lesson}.git"),
+      path = the_path,
+      verbose = FALSE
     )
   }
 

--- a/R/get_lesson.R
+++ b/R/get_lesson.R
@@ -1,6 +1,6 @@
 #' Get a carpentries lesson in XML format
 #'
-#' Download and extract a carpentries lesson in XML format. This uses [git2r::clone()]
+#' Download and extract a carpentries lesson in XML format. This uses [gert::git_clone()]
 #' to download a carpentries lesson to your computer (defaults to the temporary
 #' directory and extracts the lesson in `_episodes/` using [tinkr::to_xml()]
 #'

--- a/man/get_lesson.Rd
+++ b/man/get_lesson.Rd
@@ -21,7 +21,7 @@ lesson repository.}
 a list of xml objects, one element per episode.
 }
 \description{
-Download and extract a carpentries lesson in XML format. This uses \code{\link[git2r:clone]{git2r::clone()}}
+Download and extract a carpentries lesson in XML format. This uses \code{\link[gert:git_fetch]{gert::git_clone()}}
 to download a carpentries lesson to your computer (defaults to the temporary
 directory and extracts the lesson in \verb{_episodes/} using \code{\link[tinkr:to_xml]{tinkr::to_xml()}}
 }

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -281,7 +281,7 @@ test_that("Lessons with Rmd sources can be downloaded", {
 test_that("Non-lessons will be downloaded but rejected", {
 
   skip_if_offline()
-  skip_on_os("Windows")
+  skip_on_os("windows")
 
   expect_error(
     capture.output(get_lesson("zkamvar/notes-template", path = d)),

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -46,10 +46,7 @@ test_that("lessons can be downloaded", {
 
   testthat::skip_if_offline()
   expect_length(fs::dir_ls(d), 0)
-  expect_output(
-    lex <- get_lesson("carpentries/lesson-example", path = d),
-    "cloning into"
-  )
+  lex <- get_lesson("carpentries/lesson-example", path = d)
   # the output is a Lesson object
   expect_is(lex, "Lesson")
   # the directory exists
@@ -67,10 +64,7 @@ test_that("lessons are accessed without re-downloading", {
   # The lesson already exists in the directory
   expect_length(fs::dir_ls(d), 1)
 
-  # Nothing will print because we are using the lesson we downloaded
-  expect_silent(
-    lex <- get_lesson("carpentries/lesson-example", path = d)
-  )
+  lex <- get_lesson("carpentries/lesson-example", path = d)
 
   # the output is a Lesson object
   expect_is(lex, "Lesson")
@@ -88,10 +82,7 @@ test_that("overwriting is possible", {
 
   expect_length(fs::dir_ls(d), 1)
 
-  expect_output(
-    lex <- get_lesson("carpentries/lesson-example", path = d, overwrite = TRUE),
-    "cloning into"
-  )
+  lex <- get_lesson("carpentries/lesson-example", path = d, overwrite = TRUE)
 
   # the output is a Lesson object
   expect_is(lex, "Lesson")
@@ -275,13 +266,10 @@ test_that("Lessons with Rmd sources can be downloaded", {
   skip_if_offline()
   expect_false(fs::dir_exists(fs::path(d, "swcarpentry--r-novice-inflammation")))
 
-  expect_output({
-    expect_message(
-      rni <- get_lesson("swcarpentry/r-novice-inflammation", path = d),
-      "could not find _episodes/, using _episodes_rmd/ as the source",
-      fixed = TRUE
-    )},
-    "cloning into"
+  expect_message(
+    rni <- get_lesson("swcarpentry/r-novice-inflammation", path = d),
+    "could not find _episodes/, using _episodes_rmd/ as the source",
+    fixed = TRUE
   )
 
   expect_is(rni, "Lesson")

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -281,6 +281,7 @@ test_that("Lessons with Rmd sources can be downloaded", {
 test_that("Non-lessons will be downloaded but rejected", {
 
   skip_if_offline()
+  skip_on_os("Windows")
 
   expect_error(
     capture.output(get_lesson("zkamvar/notes-template", path = d)),


### PR DESCRIPTION
Since {sandpaper} uses {gert}, it only makes sense to have this package (whose only usage of git2r was to clone repos) to use gert instead of git2r.