### PR TITLE
Remove auto links

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9012
+Version: 0.0.0.9013
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# pegboard 0.0.0.9013
+
+ - The omnipresent `{% include links.md %}` is now removed on sandpaper
+   conversion.
+
 # pegboard 0.0.0.9012
 
  - Lesson class will now work with {sandpaper} (#24) with a new parameter `jekyll`

--- a/R/use_sandpaper.R
+++ b/R/use_sandpaper.R
@@ -10,14 +10,21 @@ use_sandpaper <- function(body, rmd = TRUE) {
     return(invisible(body))
   }
   fix_sandpaper_links(body)
+  # Remove {% include links.md %}
+  lnks <- xml2::xml_find_all(body, 
+    ".//md:text[contains(text(),'include links.md') and contains(text(),'{%')]",
+    ns = get_ns(body)
+  )
+  xml2::xml_remove(lnks)
   # Fix the code tags
   langs      <- get_code(body, "", "@ktag") # grab all of the tags
   any_python <- any(grepl("python", xml2::xml_attr(langs, "ktag")))
   purrr::walk(langs, liquid_to_commonmark, make_rmd = rmd)
+ 
   has_setup_chunk <- xml2::xml_find_lgl(
     body, 
     # setup is the first code block that is not included
-    glue::glue("boolean(./md:code_block[1][@language='r' and @include='FALSE'])"),
+    "boolean(./md:code_block[1][@language='r' and @include='FALSE'])",
     get_ns(body)
   )
   if (has_setup_chunk || rmd) {

--- a/inst/lesson-fragment/_episodes/14-looping-data-sets.md
+++ b/inst/lesson-fragment/_episodes/14-looping-data-sets.md
@@ -196,4 +196,8 @@ Link to [Home]({{ page.root }}/index.html) and to [shell]({{ site.swc_pages }}/s
 
 ![Non-working image](../no-workie.svg)
 
+This text includes a [link that isn't parsed correctly by commonmark]({{ page.root }}{% link
+index.md %}). The rest of the text should be properly parsed.
+
+
 {% include links.md %}

--- a/inst/lesson-fragment/_episodes/14-looping-data-sets.md
+++ b/inst/lesson-fragment/_episodes/14-looping-data-sets.md
@@ -195,3 +195,5 @@ Link to [Home]({{ page.root }}/index.html) and to [shell]({{ site.swc_pages }}/s
 ![Carpentries logo](https://carpentries.org/assets/img/TheCarpentries.svg)
 
 ![Non-working image](../no-workie.svg)
+
+{% include links.md %}

--- a/man/fix_sandpaper_links.Rd
+++ b/man/fix_sandpaper_links.Rd
@@ -26,15 +26,22 @@ The transformation will be to remove relative paths ("../") and replace
 Jekyll templating (e.g. "{{ page.root }}" and "{{ site.swc_pages }}" with
 either nothing or the link to software carpentry, respectively.
 }
+\note{
+This is absolutely NOT comprehensive and some links will fail to be
+converted. If this happens, please report an issue:
+\url{https://github.com/carpentries/pegboard/issues/new/}
+}
 \examples{
 
 loop <- fs::path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
 e <- Episode$new(loop)
 b <- e$body
+# Links that exist
 xml2::xml_find_all(b, ".//d1:image")
 xml2::xml_find_all(b, ".//d1:html_block")
 xml2::xml_find_all(b, ".//d1:link[contains(@destination, '{{')]")
 fix_sandpaper_links(b)
+# links that were fixed
 xml2::xml_find_all(b, ".//d1:image")
 xml2::xml_find_all(b, ".//d1:html_block")
 xml2::xml_find_all(b, ".//d1:link[contains(@destination, '{{')]")

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -39,6 +39,13 @@ test_that("Episodes can be converted to use sandpaper", {
     ".//d1:link[contains(@destination, '{{')]"
   )
 
+  liquid_links <- xml2::xml_find_all(
+    e$body,
+    ".//d1:text[contains(text(),'include links.md') and contains(text(),'{%')]"
+  )
+  expect_length(liquid_links, 1)
+  expect_equal(xml2::xml_text(liquid_links), "{% include links.md %}")
+
   expect_length(e$code, 11)
   expect_length(rel_links, 2)
   expect_equal(xml_name(rel_links), c("html_block", "image"))
@@ -73,6 +80,12 @@ test_that("Episodes can be converted to use sandpaper", {
     xml2::xml_attr(jek_links, "destination"),
     c("index.html", "https://swcarpentry.github.io/shell-novice")
   )
+
+  liquid_links <- xml2::xml_find_all(
+    e$body,
+    ".//d1:text[contains(text(),'include links.md') and contains(text(),'{%')]"
+  )
+  expect_length(liquid_links, 0)
 
   # output needs to be explicitly removed
   expect_length(e$output, 4) 

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -53,10 +53,12 @@ test_that("Episodes can be converted to use sandpaper", {
     xml2::xml_attr(rel_links, "destination"),
     c(NA, "../no-workie.svg")
   )
-  expect_length(jek_links, 2)
+  expect_length(jek_links, 3)
   expect_equal(
     xml2::xml_attr(jek_links, "destination"),
-    c("{{ page.root }}/index.html", "{{ site.swc_pages }}/shell-novice")
+    c("{{ page.root }}/index.html", 
+      "{{ site.swc_pages }}/shell-novice", 
+      "{{ page.root }}{% link")
   )
 
   # With RMD -------------------------------------------------------------------
@@ -78,7 +80,7 @@ test_that("Episodes can be converted to use sandpaper", {
   expect_match(xml2::xml_text(rel_links[[1]]), '"no-workie.svg"', fixed = TRUE)
   expect_equal(
     xml2::xml_attr(jek_links, "destination"),
-    c("index.html", "https://swcarpentry.github.io/shell-novice")
+    c("index.html", "https://swcarpentry.github.io/shell-novice", "index.html")
   )
 
   liquid_links <- xml2::xml_find_all(


### PR DESCRIPTION
This removes the `{% include links.md %}` at the bottom of all of the lessons.

It also fixes a weird situation where links are split on the liquid syntax, which throws off the commonmark parser:

```
This text, [which links to setup]({{ page.root }}{% link 
setup.md %}) is parsed weird. 
```

The commonmark only sees the link on the top line and thus gives the destination as `{{ page.root }}({% link`. 

