### PR TITLE
Allow bare blockquote elements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9013
+Version: 0.0.0.9014
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# pegboard 0.0.0.9014
+
+ - Innocent block quotes that have not been sullied by the ruthless kramdown
+   postfix operators are kept as block quotes instead of failing on `$unblock()`
+   conversion. 
+
 # pegboard 0.0.0.9013
 
  - The omnipresent `{% include links.md %}` is now removed on sandpaper

--- a/R/div.R
+++ b/R/div.R
@@ -58,6 +58,9 @@ make_div <- function(what, fenced = TRUE) {
 replace_with_div <- function(block) {
   # Grab the type of block and filter out markup
   type <- gsub("[{:}.]", "", xml2::xml_attr(block, "ktag"))
+  if (all(is.na(type))) {
+    return(invisible(block))
+  }
   # make a div tag
   div   <- make_div(type)
   open  <- xml2::xml_child(div, 1)

--- a/tests/testthat/test-div.R
+++ b/tests/testthat/test-div.R
@@ -145,3 +145,34 @@ test_that("a mix of div tags can be read", {
 
 })
 
+
+test_that("a bare block quote will be left alone when converting to divs", {
+
+  tmp <- tempfile()
+  withr::local_file(tmp)
+  txt <- glue::glue("# h1
+
+    > This is a block quote
+    
+    > This is a callout
+    {: .callout}", .open = "^", .close = "$")
+
+  writeLines(txt, tmp)
+
+  e <- Episode$new(tmp)
+  expect_length(e$get_blocks(), 2)
+  expect_length(e$unblock()$get_blocks(), 1)
+  expect_length(e$get_divs(), 1)
+
+})
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
This fixes a bug where bare blockquote elements would throw an error on the `$unblock()` method. 