### PR TITLE
Use `tinkr::yarn` as a superclass

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -40,6 +40,7 @@ Suggests:
     ggraph,
     ggplot2,
     gt,
+    cli,
     rlang
 Additional_repositories: https://carpentries.github.io/drat/ 
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,8 @@ Suggests:
     gt,
     rlang
 Additional_repositories: https://carpentries.github.io/drat/ 
+Remotes:
+  ropensci/tinkr#42
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,8 +42,6 @@ Suggests:
     gt,
     rlang
 Additional_repositories: https://carpentries.github.io/drat/ 
-Remotes:
-  ropensci/tinkr#42
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9014
+Version: 0.0.0.9015
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# pegboard 0.0.0.9015
+
+ - the Episode class is now a sub-class of the tinkr::yarn class and gains the
+   `show()`, `head()`, `tail()`, and `protect_math()` methods.
+
 # pegboard 0.0.0.9014
 
  - Innocent block quotes that have not been sullied by the ruthless kramdown

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -7,20 +7,8 @@
 #' has method specific to the Carpentries episodes.
 #' @export
 Episode <- R6::R6Class("Episode",
+  inherit = tinkr::yarn,
   public = list(
-
-    #' @field path \[`character`\] path to file on disk
-    path = NULL,
-
-    #' @field yaml \[`character`\] text block at head of file
-    yaml = NULL,
-
-    #' @field body \[`xml_document`\] an xml document of the episode
-    body = NULL,
-
-    #' @field ns \[`xml_document`\] an xml namespace set to the file name
-    ns = NULL,
-
     #' @description Create a new Episode
     #' @param path \[`character`\] path to a markdown episode file on disk
     #' @param process_tags \[`logical`\] if `TRUE` (default), kramdown tags will
@@ -44,7 +32,7 @@ Episode <- R6::R6Class("Episode",
         yaml = NULL,
         body = xml2::xml_missing()
       )
-      TOX <- purrr::safely(tinkr::yarn$new, otherwise = default, quiet = FALSE)
+      TOX <- purrr::safely(super$initialize, otherwise = default, quiet = FALSE)
       lsn <- TOX(path, sourcepos = TRUE)
       if (!is.null(lsn$error)) {
         private$record_problem(lsn$error)
@@ -271,6 +259,31 @@ Episode <- R6::R6Class("Episode",
     #' scope$get_challenge_graph()
     get_challenge_graph = function(recurse = TRUE) {
       purrr::map_dfr(self$challenges, feature_graph, recurse = recurse, .id = "Block")
+    },
+
+    #' @description show the markdown contents on the screen
+    #' @return a character vector with one line for each line of output
+    #' @examples
+    #' scope <- Episode$new(file.path(lesson_fragment(), "_episodes", "17-scope.md"))
+    #' scope$head()
+    #' scope$tail()
+    #' scope$show()
+    show = function() {
+      super$show(get_stylesheet())
+    },
+
+    #' @description show the first n lines of markdown contents on the screen
+    #' @param n the number of lines to show from the top 
+    #' @return a character vector with one line for each line of output
+    head = function(n = 6L) {
+      super$head(n, get_stylesheet())
+    },
+
+    #' @description show the first n lines of markdown contents on the screen
+    #' @param n the number of lines to show from the top 
+    #' @return a character vector with one line for each line of output
+    tail = function(n = 6L) {
+      super$tail(n, get_stylesheet())
     },
 
     #' @description write the episode to disk as markdown

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -112,8 +112,11 @@ Episode <- R6::R6Class("Episode",
     #' @description
     #' return all div elements within the Episode
     #' @param type the type of div tag (e.g. 'challenge' or 'solution')
-    get_divs = function(type = NULL) {
-      get_divs(self$body, type = type)
+    #' @param include `\[logical\]` if `TRUE`, the div tags will be included in
+    #' the output. Defaults to `FALSE`, which will only return the text between
+    #' the div tags.
+    get_divs = function(type = NULL, include = FALSE) {
+      get_divs(self$body, type = type, include = include)
     },
 
     #' @description

--- a/R/div.R
+++ b/R/div.R
@@ -99,7 +99,7 @@ replace_with_div <- function(block) {
 #' loop$unblock() # removing blockquotes and replacing with div tags
 #' pegboard:::get_divs(loop$body, 'challenge') # all challenge blocks
 #' pegboard:::get_divs(loop$body, 'solution') # all solution blocks
-get_divs <- function(body, type = NULL){
+get_divs <- function(body, type = NULL, include = FALSE){
   ns    <- get_ns(body)
   if (!any(ns == "http://carpentries.org/pegboard/")) {
     return(list())
@@ -116,7 +116,7 @@ get_divs <- function(body, type = NULL){
   # 5. Define search pattern
   res   <- purrr::map(
     tags[valid], 
-    ~find_between_tags(.x, body, "pb", "dtag[@label='{tag}']")
+    ~find_between_tags(.x, body, "pb", "dtag[@label='{tag}']", include = include)
   )
   names(res) <- tags[valid]
   res
@@ -128,6 +128,7 @@ get_divs <- function(body, type = NULL){
 #' @param body an xml document
 #' @param ns the namespace from the body
 #' @param find an xpath element to search for (without namespace tag)
+#' @param include if `TRUE`, the tags themselves will be included in the output
 #' @return a nodeset between tags that have the dtag attribute matching `tag`
 #' @keywords internal div
 #' @seealso [get_divs()] for finding labelled tags, 
@@ -148,14 +149,9 @@ get_divs <- function(body, type = NULL){
 #' tags
 #' # grab the contents of the first div tag
 #' pegboard:::find_between_tags(tags[[1]], loop$body)
-find_between_tags <- function(tag, body, ns = "pb", find = "dtag[@label='{tag}']") {
+find_between_tags <- function(tag, body, ns = "pb", find = "dtag[@label='{tag}']", include = FALSE) {
   block  <- glue::glue("{ns}:{glue::glue(find)}")
-  after  <- "following-sibling::"
-  before <- "preceding-sibling::"
-  after_first_tag <- glue::glue("{after}{block}")
-  before_last_tag <- glue::glue("{before}md:*[{before}{block}]")
-  xpath <- glue::glue(".//{after_first_tag}/{before_last_tag}")
-  xml2::xml_find_all(body, xpath, get_ns(body))
+  tinkr::find_between(body, get_ns(body), pattern = block, include = include)
 }
 
 #' Add labels to div tags in the form of a "dtag" node with a paired "label"

--- a/R/div.R
+++ b/R/div.R
@@ -692,7 +692,11 @@ find_div_pairs <- function(divs, close = "(^ *?[<][/]div[>] *?\n?$|^[:]{3,80}$)"
   if (n_tags != sum(grepl(close, divs))) { 
     stop("the number of closing tags must equal the number of opening tags")
   }
+  pairs <- sub(close, ")", divs)
+  find_nested_pairs(pairs, n_tags, n_item)
+}
 
+find_nested_pairs <- function(pairs, n_tags, n_item) {
   tag_stack <- integer(n_tags)
   labels    <- integer(n_item)
   labels[1]    <- 1L
@@ -702,7 +706,8 @@ find_div_pairs <- function(divs, close = "(^ *?[<][/]div[>] *?\n?$|^[:]{3,80}$)"
   this_tag     <- 1L
   tag_count    <- 1L
   while(this_item <= n_item) {
-    is_closed <- grepl(close, divs[this_item])
+    is_closed <- pairs[this_item] == ")"
+    # is_closed <- grepl(close, divs[this_item])
     # Tags that are closed will be labelled with the current tag on the stack
     # and then have the stack decreased
     if (is_closed) {

--- a/R/div.R
+++ b/R/div.R
@@ -359,18 +359,9 @@ make_div_table <- function(nodes, path = NULL, yaml = NULL) {
     stringsAsFactors = FALSE
   )
  
-  labels    <- tryCatch(find_div_pairs(res$div), error = function(e) e)
+  labels <- tryCatch(find_div_pairs(res$div), error = function(e) e)
   if (inherits(labels, "error")) {
-    div <- sub("^:+", "  [close]", get_div_class(res$div))
-    if (Sys.getenv("CI") == "") {
-      msg <- "{path}:{res$line + yaml}\t | tag: {div}"
-    } else {
-      msg <- "::warning file={path},line={res$line + yaml}::Possibly mismatched section tag"
-    }
-    msg <- c(glue::glue("There was at least one mismatched section tag in {path}."),
-     "Here are the locations of all the tags I found:", 
-     glue::glue(msg))
-    stop(glue::glue_collapse(msg, sep = "\n"))
+    raise_div_error(res, path, yaml, type = labels$message)
   }
   # find the divs that are closing tags
   ends      <- duplicated(labels)
@@ -380,6 +371,28 @@ make_div_table <- function(nodes, path = NULL, yaml = NULL) {
   # tell us if the tag should go before or after the node
   res$pos   <- ifelse(ends, "after", "before")
   split(res, res$node)
+}
+
+# Raise an error when divs are unbalanced
+#
+# @param res a data frame containing 
+#   - node: a unique identifier for each div element
+#   - div a each div element
+#   - line the line number of the div element
+# @param path the path of the file containing the div
+# @param yaml an integer offset representing the length of the yaml header
+raise_div_error <- function(res, path, yaml, type) {
+  div <- sub(div_close_regex(), "  [close]", get_div_class(res$div))
+  ci <- Sys.getenv("CI") != ""
+  if (ci) {
+    msg <- "::warning file={path},line={res$line + yaml}::Possibly mismatched section tag"
+  } else {
+    msg <- "{path}:{res$line + yaml}\t | tag: {div}"
+  }
+  msg <- c(glue::glue("Missing {type} section (div) tag in {path}."),
+    if (ci) "" else "Here is a list of all tags in the file:", 
+    glue::glue(msg))
+  stop(glue::glue_collapse(msg, sep = "\n"), call. = FALSE)
 }
 
 #' Add a pegboard node before or after a node
@@ -660,6 +673,10 @@ get_div_class <- function(div) {
   trimws(sub('^(.+?class[=]["\']|[:]{3,}?)([- a-zA-Z0-9]+?)(["\'].+?|[:]*?)$', '\\2', div))
 }
 
+div_close_regex <- function() {
+  "(^ *?[<][/]div[>] *?\n?$|^[:]{3,80}$)"
+} 
+
 #' Make paired labels for opening and closing div tags
 #'
 #' @param nodes a character vector of div open and close tags
@@ -686,17 +703,26 @@ get_div_class <- function(div) {
 #'   "</div>", 
 #' "</div>")
 #' pegboard:::find_div_pairs(nodes)
-find_div_pairs <- function(divs, close = "(^ *?[<][/]div[>] *?\n?$|^[:]{3,80}$)") {
-  n_item <- length(divs)
-  n_tags <- n_item / 2
-  if (n_tags != sum(grepl(close, divs))) { 
-    stop("the number of closing tags must equal the number of opening tags")
-  }
+find_div_pairs <- function(divs, close = div_close_regex()) {
   pairs <- sub(close, ")", divs)
-  find_nested_pairs(pairs, n_tags, n_item)
+  pairs[pairs != ")"] <- "("
+  close_tags <- sum(pairs == ")")
+  open_tags  <- sum(pairs == "(")
+  if (close_tags != open_tags) {
+    tags <- c(open = open_tags, close = close_tags)
+    bad <- if (open_tags < close_tags) 1L else 2L
+    cli::cli_alert_danger("A section (div) tag mis-match was detected.")
+    msg <- c("There are not enough {names(tags)[bad]} tags ({tags[bad]}) for",
+      "the number of {names(tags)[-bad]} tags ({tags[-bad]}).")
+    msg <- paste(msg, collapse = " ")
+    stop(cli::cli_alert_danger(msg, id = names(tags)[bad]), call. = FALSE)
+  }
+  label_pairs(pairs, close_tags)
 }
 
-find_nested_pairs <- function(pairs, n_tags, n_item) {
+label_pairs <- function(pairs, n_tags, reverse = FALSE) {
+  n_item <- length(pairs)
+  if (reverse) pairs <- rev(pairs)
   tag_stack <- integer(n_tags)
   labels    <- integer(n_item)
   labels[1]    <- 1L
@@ -706,7 +732,7 @@ find_nested_pairs <- function(pairs, n_tags, n_item) {
   this_tag     <- 1L
   tag_count    <- 1L
   while(this_item <= n_item) {
-    is_closed <- pairs[this_item] == ")"
+    is_closed <- pairs[this_item] == if (reverse) "(" else ")"
     # is_closed <- grepl(close, divs[this_item])
     # Tags that are closed will be labelled with the current tag on the stack
     # and then have the stack decreased
@@ -719,9 +745,9 @@ find_nested_pairs <- function(pairs, n_tags, n_item) {
       tag_count <- tag_count + 1L
       this_tag  <- this_tag  + 1L
       tag_stack[this_tag] <- tag_count
-      labels[this_item] <- tag_stack[this_tag]
+      labels[this_item]   <- tag_stack[this_tag]
     }
     this_item <- this_item + 1L
   }
-  labels
+  if (reverse) rev(labels) else labels
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -58,12 +58,10 @@ NS <- function(x, generic = TRUE) {
 }
 
 get_ns <- function(body) {
-  ns <- xml2::xml_ns(body)
-  # assuming that the first namespace is commonmark
-  ns   <- c(ns[1], ns[ns == "http://carpentries.org/pegboard/"][1])
-  ns[] <- c("md", "pb")
-  ns   <- as.list(ns[!is.na(names(ns))])
-  xml2::xml_ns_rename(xml2::xml_ns(body), ns)
+  structure(
+    c(tinkr::md_ns(), pb = "http://carpentries.org/pegboard/"),
+    class = "xml_namespace"
+  )
 }
 
 

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -282,13 +282,17 @@ label all the div elements within the Episode to extract them with
 \subsection{Method \code{get_divs()}}{
 return all div elements within the Episode
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Episode$get_divs(type = NULL)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Episode$get_divs(type = NULL, include = FALSE)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{type}}{the type of div tag (e.g. 'challenge' or 'solution')}
+
+\item{\code{include}}{\verb{\[logical\]} if \code{TRUE}, the div tags will be included in
+the output. Defaults to \code{FALSE}, which will only return the text between
+the div tags.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -60,6 +60,15 @@ scope <- Episode$new(file.path(lesson_fragment(), "_episodes", "17-scope.md"))
 scope$get_challenge_graph()
 
 ## ------------------------------------------------
+## Method `Episode$show`
+## ------------------------------------------------
+
+scope <- Episode$new(file.path(lesson_fragment(), "_episodes", "17-scope.md"))
+scope$head()
+scope$tail()
+scope$show()
+
+## ------------------------------------------------
 ## Method `Episode$write`
 ## ------------------------------------------------
 
@@ -444,8 +453,23 @@ scope$get_challenge_graph()
 \if{html}{\out{<a id="method-show"></a>}}
 \if{latex}{\out{\hypertarget{method-show}{}}}
 \subsection{Method \code{show()}}{
+show the markdown contents on the screen
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Episode$show()}\if{html}{\out{</div>}}
+}
+
+\subsection{Returns}{
+a character vector with one line for each line of output
+}
+\subsection{Examples}{
+\if{html}{\out{<div class="r example copy">}}
+\preformatted{scope <- Episode$new(file.path(lesson_fragment(), "_episodes", "17-scope.md"))
+scope$head()
+scope$tail()
+scope$show()
+}
+\if{html}{\out{</div>}}
+
 }
 
 }
@@ -453,19 +477,41 @@ scope$get_challenge_graph()
 \if{html}{\out{<a id="method-head"></a>}}
 \if{latex}{\out{\hypertarget{method-head}{}}}
 \subsection{Method \code{head()}}{
+show the first n lines of markdown contents on the screen
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Episode$head(n = 6L)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{the number of lines to show from the top}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+a character vector with one line for each line of output
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-tail"></a>}}
 \if{latex}{\out{\hypertarget{method-tail}{}}}
 \subsection{Method \code{tail()}}{
+show the first n lines of markdown contents on the screen
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Episode$tail(n = 6L)}\if{html}{\out{</div>}}
 }
 
+\subsection{Arguments}{
+\if{html}{\out{<div class="arguments">}}
+\describe{
+\item{\code{n}}{the number of lines to show from the top}
+}
+\if{html}{\out{</div>}}
+}
+\subsection{Returns}{
+a character vector with one line for each line of output
+}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-write"></a>}}

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -96,18 +96,8 @@ loop$unblock()
 loop$get_blocks() # no blocks
 loop$code # now there are two blocks with challenge tags
 }
-\section{Public fields}{
-\if{html}{\out{<div class="r6-fields">}}
-\describe{
-\item{\code{path}}{[\code{character}] path to file on disk}
-
-\item{\code{yaml}}{[\code{character}] text block at head of file}
-
-\item{\code{body}}{[\code{xml_document}] an xml document of the episode}
-
-\item{\code{ns}}{[\code{xml_document}] an xml namespace set to the file name}
-}
-\if{html}{\out{</div>}}
+\section{Super class}{
+\code{\link[tinkr:yarn]{tinkr::yarn}} -> \code{Episode}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}
@@ -154,12 +144,23 @@ loop$code # now there are two blocks with challenge tags
 \item \href{#method-move_keypoints}{\code{Episode$move_keypoints()}}
 \item \href{#method-move_questions}{\code{Episode$move_questions()}}
 \item \href{#method-get_challenge_graph}{\code{Episode$get_challenge_graph()}}
+\item \href{#method-show}{\code{Episode$show()}}
+\item \href{#method-head}{\code{Episode$head()}}
+\item \href{#method-tail}{\code{Episode$tail()}}
 \item \href{#method-write}{\code{Episode$write()}}
 \item \href{#method-reset}{\code{Episode$reset()}}
 \item \href{#method-isolate_blocks}{\code{Episode$isolate_blocks()}}
 \item \href{#method-unblock}{\code{Episode$unblock()}}
 \item \href{#method-clone}{\code{Episode$clone()}}
 }
+}
+\if{html}{
+\out{<details open ><summary>Inherited methods</summary>}
+\itemize{
+\item \out{<span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="add_md">}\href{../../tinkr/html/yarn.html#method-add_md}{\code{tinkr::yarn$add_md()}}\out{</span>}
+\item \out{<span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="protect_math">}\href{../../tinkr/html/yarn.html#method-protect_math}{\code{tinkr::yarn$protect_math()}}\out{</span>}
+}
+\out{</details>}
 }
 \if{html}{\out{<hr>}}
 \if{html}{\out{<a id="method-new"></a>}}
@@ -436,6 +437,33 @@ scope$get_challenge_graph()
 }
 \if{html}{\out{</div>}}
 
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-show"></a>}}
+\if{latex}{\out{\hypertarget{method-show}{}}}
+\subsection{Method \code{show()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Episode$show()}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-head"></a>}}
+\if{latex}{\out{\hypertarget{method-head}{}}}
+\subsection{Method \code{head()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Episode$head(n = 6L)}\if{html}{\out{</div>}}
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-tail"></a>}}
+\if{latex}{\out{\hypertarget{method-tail}{}}}
+\subsection{Method \code{tail()}}{
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Episode$tail(n = 6L)}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/find_between_tags.Rd
+++ b/man/find_between_tags.Rd
@@ -4,7 +4,13 @@
 \alias{find_between_tags}
 \title{Find nodes between two nodes with a given dtag}
 \usage{
-find_between_tags(tag, body, ns = "pb", find = "dtag[@label='{tag}']")
+find_between_tags(
+  tag,
+  body,
+  ns = "pb",
+  find = "dtag[@label='{tag}']",
+  include = FALSE
+)
 }
 \arguments{
 \item{tag}{an integer representing a unique dtag attribute}
@@ -14,6 +20,8 @@ find_between_tags(tag, body, ns = "pb", find = "dtag[@label='{tag}']")
 \item{ns}{the namespace from the body}
 
 \item{find}{an xpath element to search for (without namespace tag)}
+
+\item{include}{if \code{TRUE}, the tags themselves will be included in the output}
 }
 \value{
 a nodeset between tags that have the dtag attribute matching \code{tag}

--- a/man/find_div_pairs.Rd
+++ b/man/find_div_pairs.Rd
@@ -4,7 +4,7 @@
 \alias{find_div_pairs}
 \title{Make paired labels for opening and closing div tags}
 \usage{
-find_div_pairs(divs, close = "(^ *?[<][/]div[>] *?\\n?$|^[:]{3,80}$)")
+find_div_pairs(divs, close = div_close_regex())
 }
 \arguments{
 \item{close}{the regex for a valid closing tag}

--- a/man/get_divs.Rd
+++ b/man/get_divs.Rd
@@ -4,7 +4,7 @@
 \alias{get_divs}
 \title{Get paired div blocks}
 \usage{
-get_divs(body, type = NULL)
+get_divs(body, type = NULL, include = FALSE)
 }
 \arguments{
 \item{body}{an xml document}

--- a/tests/testthat/test-div.R
+++ b/tests/testthat/test-div.R
@@ -110,7 +110,7 @@ test_that("label_div_tags() will throw an error if there are missing tags", {
   ex <- tinkr::yarn$new(file.path(test_path(), "examples", "mismatched-div.txt"), sourcepos = TRUE)
   expect_error(label_div_tags(ex), "mismatched-div.txt:5\t| tag: challenge, fixed = TRUE")
   Sys.setenv(CI = "true")
-  expect_error(label_div_tags(ex), "::warning file=.+?mismatched-div[.]txt,line=5")
+  expect_error(label_div_tags(ex), "::warning file=.+?mismatched-div[.]txt,line=5::check for the corresponding close tag")
 
 })
 


### PR DESCRIPTION
The whole purpose of having R6 classes is that we could do proper inheritance in R and I've been using the output of the yarn object to seed the Episode class, but not reaping any benefits of the yarn object.

This PR will better integrate the features that have been migrated to {tinkr}. 