### PR TITLE
Modify namespace declarations

### DIFF
--- a/R/div.R
+++ b/R/div.R
@@ -245,7 +245,7 @@ label_div_tags <- function(body) {
 
 #' @rdname div_labels
 find_div_tags <- function(body) {
-  ns     <- "md"
+  ns     <- "md:"
   # Find all div tags in html blocks or fenced div tags in paragraphs
   pblock <- "starts-with(text(), ':::')"
   divs   <- ".//{ns}html_block[contains(text(), '<div') or contains(text(), '</div')]"

--- a/R/div.R
+++ b/R/div.R
@@ -150,7 +150,8 @@ get_divs <- function(body, type = NULL, include = FALSE){
 #' # grab the contents of the first div tag
 #' pegboard:::find_between_tags(tags[[1]], loop$body)
 find_between_tags <- function(tag, body, ns = "pb", find = "dtag[@label='{tag}']", include = FALSE) {
-  block  <- glue::glue("{ns}:{glue::glue(find)}")
+  ns <- paste0(ns, ":")
+  block  <- glue::glue("{ns}{glue::glue(find)}")
   tinkr::find_between(body, get_ns(body), pattern = block, include = include)
 }
 
@@ -247,8 +248,8 @@ find_div_tags <- function(body) {
   ns     <- "md"
   # Find all div tags in html blocks or fenced div tags in paragraphs
   pblock <- "starts-with(text(), ':::')"
-  divs   <- ".//{ns}:html_block[contains(text(), '<div') or contains(text(), '</div')]"
-  ndiv   <- ".//{ns}:paragraph[{ns}:text[{pblock}]]"
+  divs   <- ".//{ns}html_block[contains(text(), '<div') or contains(text(), '</div')]"
+  ndiv   <- ".//{ns}paragraph[{ns}text[{pblock}]]"
   xpath  <- glue::glue("{glue::glue(divs)} | {glue::glue(ndiv)}")
   nodes  <- xml2::xml_find_all(body, xpath, get_ns(body))
   nodes
@@ -597,7 +598,7 @@ clean_fenced_divs <- function(body) {
   # Find the parents and then see if they have multiple child elements that
   # need to be split off into separate paragraphs. 
   predicate <- "[starts-with(text(), ':::')]"
-  parent_xslt  <- glue::glue(".//{ns}:paragraph[{ns}:text{predicate}]")
+  parent_xslt  <- glue::glue(".//{ns}paragraph[{ns}text{predicate}]")
   is_a_tag     <- glue::glue("boolean(self::*{predicate})")
   rents        <- xml2::xml_find_all(body, parent_xslt)
   names(rents) <- xml2::xml_attr(rents, "sourcepos")

--- a/R/fix_links.R
+++ b/R/fix_links.R
@@ -29,7 +29,7 @@ fix_link_type <- function(type, body) {
 find_lesson_links <- function(body, type = "rel_link") {
   ns <- NS(body)
   xml2::xml_find_all(body,
-    glue::glue(".//{ns}:paragraph/{ns}:text[{LINKS[[type]]}][not(@klink)]")
+    glue::glue(".//{ns}paragraph/{ns}text[{LINKS[[type]]}][not(@klink)]")
   )
 }
 

--- a/R/fix_sandpaper_links.R
+++ b/R/fix_sandpaper_links.R
@@ -40,10 +40,10 @@ fix_sandpaper_links <- function(body) {
   lnk_type <- glue::glue("{jek_dest} or {rel_dest}")
 
   # Fix links and markdown images
-  link_search <- glue::glue(".//{ns}:link[{lnk_type}]")
-  img_search  <- glue::glue(".//{ns}:image[{lnk_type}]")
+  link_search <- glue::glue(".//{ns}link[{lnk_type}]")
+  img_search  <- glue::glue(".//{ns}image[{lnk_type}]")
   html_search <- glue::glue(
-    ".//{ns}:html_block[{jek_text} or {rel_text}]"
+    ".//{ns}html_block[{jek_text} or {rel_text}]"
   )
   links <- xml2::xml_find_all(body, link_search)
   lattr <- xml2::xml_attr(links, "destination")
@@ -57,7 +57,7 @@ fix_sandpaper_links <- function(body) {
   if (any(missing_links)) {
     ml <- links[missing_links]
     txt <- xml2::xml_find_first(ml, 
-      glue::glue(".//following-sibling::{ns}:text[contains(text(), '%}')]")
+      glue::glue(".//following-sibling::{ns}text[contains(text(), '%}')]")
     )
     irl_txt <- xml2::xml_text(txt)
     pattern <- "^(.+?) ?[%][}][)](.*?)$"

--- a/R/get_blocks.R
+++ b/R/get_blocks.R
@@ -30,7 +30,7 @@ get_blocks <- function(body, type = NULL, level = 0) {
   ns <- NS(body)
 
   # Gather all block quotes with increasing nesting levels
-  BLOCK_QUOTE <- glue::glue("{ns}:block_quote")
+  BLOCK_QUOTE <- glue::glue("{ns}block_quote")
   IS_TYPE     <- block_type(ns = ns, type = type)
   # "chip off the ol' block"
   OL_BLOCK    <- glue::glue("ancestor::{BLOCK_QUOTE}")

--- a/R/get_code.R
+++ b/R/get_code.R
@@ -33,7 +33,7 @@ get_code <- function(body, type = ".language-", attr = "@ktag") {
   ns <- attr(xml2::xml_ns(body), "names")[[1]]
 
   # Find the end of the challenge block ----------------------------------------
-  block <- glue::glue(".//{ns}:code_block")
+  block <- glue::glue(".//{ns}code_block")
   if (is.null(attr)) {
     challenge <- block
   } else if (is.null(type)) {

--- a/R/get_code.R
+++ b/R/get_code.R
@@ -30,7 +30,7 @@ get_code <- function(body, type = ".language-", attr = "@ktag") {
   # be code blocks.
 
   # Namespace for the document is listed in the attributes
-  ns <- attr(xml2::xml_ns(body), "names")[[1]]
+  ns <- NS(body)
 
   # Find the end of the challenge block ----------------------------------------
   block <- glue::glue(".//{ns}code_block")

--- a/R/get_list_block.R
+++ b/R/get_list_block.R
@@ -19,7 +19,7 @@ get_list_block <- function(self, type = "questions", in_yaml = TRUE) {
   # TODO: remove this if we determine that {dovetail} is an impossibility
   if (is.null(q)) {
     ns <- NS(self$body)
-    xpath <- ".//{ns}:code_block[@info='{{{type}}}' or @language='{type}']"
+    xpath <- ".//{ns}code_block[@info='{{{type}}}' or @language='{type}']"
     xpath <- glue::glue(xpath)
     q <- xml2::xml_find_first(self$body, xpath)
   } else {

--- a/R/get_solutions.R
+++ b/R/get_solutions.R
@@ -44,7 +44,7 @@ get_solutions <- function(body, type = c("block", "div", "chunk"), parent = NULL
     return(out)
   }
   # Namespace for the document is listed in the attributes
-  ns <- attr(xml2::xml_ns(body), "names")[[1]]
+  ns <- NS(body)
 
   # convenience namespace aliases
   bq <- glue::glue("{ns}block_quote")

--- a/R/get_solutions.R
+++ b/R/get_solutions.R
@@ -47,15 +47,15 @@ get_solutions <- function(body, type = c("block", "div", "chunk"), parent = NULL
   ns <- attr(xml2::xml_ns(body), "names")[[1]]
 
   # convenience namespace aliases
-  bq <- glue::glue("{ns}:block_quote")
+  bq <- glue::glue("{ns}block_quote")
 
   parent_tag <- block_type(ns = ns, type = parent)
   solution_tag <- block_type(ns = ns, type = ".solution")
 
   # Finding blocks that are missing tags
   #   1. The block starts with a Solution
-  solution_head <- glue::glue("{ns}:text[starts-with(text(),'Solu')]")
-  has_header    <- glue::glue("[{ns}:heading[{solution_head}] ")
+  solution_head <- glue::glue("{ns}text[starts-with(text(),'Solu')]")
+  has_header    <- glue::glue("[{ns}heading[{solution_head}] ")
   #   2. and does not have a solution tag
   no_solution_tag  <- "and not(@ktag)]"
   # Find and tag

--- a/R/isolate_kram_blocks.R
+++ b/R/isolate_kram_blocks.R
@@ -9,7 +9,7 @@
 #' @keywords internal
 isolate_kram_blocks <- function(body, predicate = "") {
   ns <- NS(body)
-  kblock <- glue::glue("{ns}:block_quote[@ktag]{predicate}")
+  kblock <- glue::glue("{ns}block_quote[@ktag]{predicate}")
   txt <- xml2::xml_find_all(
     body,
     glue::glue(".//text()[not(ancestor-or-self::{kblock})]")

--- a/R/kramdown_tags.R
+++ b/R/kramdown_tags.R
@@ -136,7 +136,7 @@ set_ktag_block <- function(tags) {
   # When this happens, we need to find the nested block quote and
   # get its parents
   if (!balanced && length(parents) < length(are_tags) && length(parents) == 1) {
-    blq <- glue::glue(".//{ns}:block_quote[not(@ktag)]/*")
+    blq <- glue::glue(".//{ns}block_quote[not(@ktag)]/*")
     if (xml2::xml_find_lgl(parents, glue::glue("boolean({blq})"))) {
       parents <- xml2::xml_parents(
         xml2::xml_find_first(parents, blq)
@@ -214,7 +214,7 @@ set_ktag_code <- function(tag) {
     problems <- c(problems, list(element = tag, reason = msg))
   } else {
     # Find the end of the challenge block ------------------------------------
-    code_block_sib <- glue::glue(".//preceding-sibling::{ns}:code_block[1]")
+    code_block_sib <- glue::glue(".//preceding-sibling::{ns}code_block[1]")
     the_block      <- xml2::xml_find_first(tag, code_block_sib)
 
     # Assign the tag attribute -----------------------------------------------

--- a/R/kramdown_tags.R
+++ b/R/kramdown_tags.R
@@ -8,7 +8,7 @@ kramdown_tags <- function(body) {
   # Namespace for the document is listed in the attributes
   ns <- NS(body)
   tag <- "starts-with(text(), '{:') and contains(text(), '}')"
-  srch <- glue::glue(".//<ns>:paragraph[<ns>:text[<tag>]]",
+  srch <- glue::glue(".//<ns>paragraph[<ns>text[<tag>]]",
     .open  = "<",
     .close = ">"
   )

--- a/R/to_dovetail.R
+++ b/R/to_dovetail.R
@@ -46,7 +46,7 @@ to_dovetail <- function(block, token = "#'") {
   )
 
   # 3. Tag the first child as a solution
-  sln <- glue::glue(".//<ns>:block_quote[@ktag='{: .solution}']",
+  sln <- glue::glue(".//<ns>block_quote[@ktag='{: .solution}']",
     .open  = "<",
     .close = ">"
   )

--- a/R/to_dovetail.R
+++ b/R/to_dovetail.R
@@ -35,7 +35,7 @@ to_dovetail <- function(block, token = "#'") {
   block_type <- gsub("[{}: .]", "", xml2::xml_attr(block, "ktag"))
   copy_xml <- "tinkr" %:% "copy_xml"
   cpy <- copy_xml(xml2::xml_root(block))
-  rcd <- xml2::xml_find_all(cpy, glue::glue(".//{ns}:code_block[@language]"))
+  rcd <- xml2::xml_find_all(cpy, glue::glue(".//{ns}code_block[@language]"))
   purrr::walk(rcd, "tinkr" %:% "to_info")
 
 
@@ -98,7 +98,7 @@ to_dovetail <- function(block, token = "#'") {
   # #'
   # Because we don't comment code blocks with the token, we have to add a dummy
   # paragraph before the code block
-  oxy_code <- xml2::xml_find_all(cpy, glue::glue(".//{ns}:code_block[@xygen]"))
+  oxy_code <- xml2::xml_find_all(cpy, glue::glue(".//{ns}code_block[@xygen]"))
   if (length(oxy_code) > 0) {
     oxy_tags <- glue::glue("@{xml2::xml_attr(oxy_code, 'xygen')}")
     oxy_tags <- purrr::map(oxy_tags, xml_new_paragraph, xml2::xml_ns(cpy))
@@ -113,9 +113,9 @@ to_dovetail <- function(block, token = "#'") {
     purrr::walk(oxy_code, xml2::xml_set_attr, "xygen", NULL)
   }
   # parent is the document
-  to_comment <- glue::glue(".//{ns}:*[parent::{ns}:document]")
+  to_comment <- glue::glue(".//{ns}*[parent::{ns}document]")
   # but skip code blocks
-  not_code   <- glue::glue("[not(ancestor-or-self::{ns}:code_block)]")
+  not_code   <- glue::glue("[not(ancestor-or-self::{ns}code_block)]")
   nblks      <- xml2::xml_find_all(cpy, glue::glue("{to_comment}{not_code}"))
   # set the token as the comment attribute
   xml2::xml_set_attr(nblks, "comment", token)

--- a/R/utils.R
+++ b/R/utils.R
@@ -51,10 +51,11 @@ read_markdown_files <- function(src, ...) {
 # Get a character vector of the namespace
 NS <- function(x, generic = TRUE) {
   if (generic) {
-    attr(xml2::xml_ns(x), "names")[[1]]
+    res <- attr(xml2::xml_ns(x), "names")[[1]]
   } else {
-    attr(get_ns(x), "names")[[1]]
+    res <- attr(get_ns(x), "names")[[1]]
   }
+  paste0(res, ":")
 }
 
 get_ns <- function(body) {
@@ -195,7 +196,7 @@ after_thing <- function(body, thing = "code_block") {
   ns <- NS(body)
   tng <- xml2::xml_find_first(
     body,
-    glue::glue(".//preceding-sibling::{ns}:{thing}[1]")
+    glue::glue(".//preceding-sibling::{ns}{thing}[1]")
   )
 
   # Returns TRUE if the last line of the thing is adjacent to the first line of
@@ -240,7 +241,7 @@ get_sibling_block <- function(tags) {
   ns <- NS(tags)
   block <- xml2::xml_find_all(
     tags,
-    glue::glue("preceding-sibling::{ns}:block_quote[1]")
+    glue::glue("preceding-sibling::{ns}block_quote[1]")
   )
 
   if (are_adjacent(block[[1]], tags)) {
@@ -255,7 +256,7 @@ challenge_is_sibling <- function(node) {
   predicate <- "text()='{: .challenge}'"
   xml2::xml_find_lgl(
     node,
-    glue::glue("boolean(following-sibling::{ns}:paragraph/{ns}:text[{predicate}])")
+    glue::glue("boolean(following-sibling::{ns}paragraph/{ns}text[{predicate}])")
   )
 }
 


### PR DESCRIPTION
This modifies all of the namespace declarations in the XPath queries so that it will be easier to replace/remove them down the line when https://github.com/ropensci/tinkr/issues/48 is implemented.

## Background

Before I fully understood the implications and uses of XML namespaces, I had awkwardly tried to construct XPath queries using glue with the pattern `{ns}:{QUERY}`. If I wanted to search for a paragraph, this would turn into `d1:paragraph` for a default namespace. If there was no namespace assigned, this would turn into `:paragraph`, which is an invalid query :scream: 

This PR changes all of the `{ns}:{QUERY}` patterns to `{ns}{QUERY}`so that having no namespace assigned will turn it into `{QUERY}`, meaning that we have fewer places to let our code fail.