### PR TITLE
fix duplicate heading display

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9017
+Version: 0.0.0.9018
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# pegboard 0.0.0.9018
+
+- `Episode$validate_headings()` now properly displays duplicated headings.
+
 # pegboard 0.0.0.9017
 
  - The Lesson class now respects the order of the contents in `config.yaml` 

--- a/R/heading_tree.R
+++ b/R/heading_tree.R
@@ -24,10 +24,12 @@ heading_tree <- function(headings, lname = NULL, suffix = NULL) {
   )
   hlevels[1] <- 0L
   hlabels[1] <- "# Lesson:"
-  htree   <- data.frame(
-    heading = hnames,
+  hnames <- paste(hlabels, hnames)
+  htree <- data.frame(
+    heading  = hnames,
     children = I(vector(mode = "list", length = length(hnames))),
-    labels = paste(hlabels, hnames, suffix),
+    labels   = paste(hnames, suffix),
+    level    = hlevels,
     stringsAsFactors = FALSE
   )
 
@@ -67,4 +69,42 @@ heading_tree <- function(headings, lname = NULL, suffix = NULL) {
 
   htree
 }
+
+label_duplicates <- function(htree, cli = FALSE) {
+
+  get_duplicated <- function(i) duplicated(i) | duplicated(i, fromLast = TRUE)
+  the_clones <- lapply(htree$children, get_duplicated)
+  has_twins <- vapply(the_clones, any, logical(1))
+
+  dtree <- htree$labels
+  for (i in which(has_twins)) {
+    this_level     <- htree$level[i]
+    the_children   <- htree$level == this_level + if (this_level == 0L) 2L else 1L
+    the_duplicated <- the_children & get_duplicated(htree$heading)
+    dtree          <- append_labels(
+      l = dtree,
+      i = the_duplicated,
+      e = if (cli) cli::style_inverse("(duplicated)") else "(duplicated)",
+      cli = FALSE
+    )
+    # This part is needed to fix a feature in CLI that assumes unordered data
+    # 
+    # If there is a child of a duplicated node, CLI does not know where to put
+    # that child and will not print it.
+    #
+    # Here, we are adding the number of children to the heading so that CLI can
+    # identify it as unique entity and respect its children.
+    these_headings <- htree$heading[the_duplicated]
+    these_children <- htree$children[[i]][the_clones[[i]]]
+    if (identical(these_headings, these_children)) {
+      grandchildren <- lengths(htree$children[the_duplicated])
+      new_ids       <- paste(these_headings, grandchildren)
+      htree$heading[the_duplicated]        <- new_ids
+      htree$children[[i]][the_clones[[i]]] <- new_ids
+    }
+  }
+  htree$labels <- dtree
+  list(test = !any(has_twins), tree = htree)
+}
+
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -11,11 +11,29 @@
       # Lesson: "Errors in Headings" 
       -# First heading throws an error (must be level 2) (first level heading)
       ---### This heading throws another error  (non-sequential heading jump)
-      --## This heading is okay 
+      --## This heading is okay  (duplicated)
       --## This heading is okay  (duplicated)
       ---### This heading is okay 
       --##   (no name)
       --## This last heading is okay 
+
+---
+
+    Code
+      expect_equal(sum(loop$validate_headings()), 4L)
+    Message <simpleMessage>
+      ! All headings must have unique IDs.
+      # Lesson: "Looping Over Data Sets" 
+      --## Use a for loop to process files given a list of their names. 
+      --## Use glob.glob to find sets of files whose names match a pattern. 
+      --## Use glob and for to process batches of files. 
+      --## Determining Matches 
+      --## Solution  (duplicated)
+      --## Minimum File Size 
+      --## Solution  (duplicated)
+      --## Comparing Data 
+      --## Solution  (duplicated)
+      ---### ZNK test links and images 
 
 # reporters will work [plain]
 
@@ -32,11 +50,11 @@
       # Lesson: "Errors in Headings" 
       +-# First heading throws an error (must be level 2) (first level heading)
       | +-### This heading throws another error  (non-sequential heading jump)
-      | +-## This heading is okay 
-      | +-## This heading is okay 
+      | +-## This heading is okay  (duplicated)
+      | +-## This heading is okay  (duplicated)
+      | | \-### This heading is okay 
       | +-##   (no name)
       | \-## This last heading is okay 
-      \-## This heading is okay 
     Message <cliMessage>
       --------------------------------------------------------------------------------
 
@@ -55,11 +73,11 @@
       # Lesson: "Errors in Headings" 
       +-# First heading throws an error [7m(must be level 2)[27m [7m(first level heading)[27m
       | +-### This heading throws another error  [7m(non-sequential heading jump)[27m
-      | +-## This heading is okay 
-      | +-## This heading is okay 
+      | +-## This heading is okay  [7m(duplicated)[27m
+      | +-## This heading is okay  [7m(duplicated)[27m
+      | | \-### This heading is okay 
       | +-##   [7m(no name)[27m
       | \-## This last heading is okay 
-      \-## This heading is okay 
     Message <cliMessage>
       --------------------------------------------------------------------------------
 
@@ -78,11 +96,11 @@
       # Lesson: "Errors in Headings" 
       ├─# First heading throws an error (must be level 2) (first level heading)
       │ ├─### This heading throws another error  (non-sequential heading jump)
-      │ ├─## This heading is okay 
-      │ ├─## This heading is okay 
+      │ ├─## This heading is okay  (duplicated)
+      │ ├─## This heading is okay  (duplicated)
+      │ │ └─### This heading is okay 
       │ ├─##   (no name)
       │ └─## This last heading is okay 
-      └─## This heading is okay 
     Message <cliMessage>
       ────────────────────────────────────────────────────────────────────────────────
 
@@ -101,11 +119,99 @@
       # Lesson: "Errors in Headings" 
       ├─# First heading throws an error [7m(must be level 2)[27m [7m(first level heading)[27m
       │ ├─### This heading throws another error  [7m(non-sequential heading jump)[27m
-      │ ├─## This heading is okay 
-      │ ├─## This heading is okay 
+      │ ├─## This heading is okay  [7m(duplicated)[27m
+      │ ├─## This heading is okay  [7m(duplicated)[27m
+      │ │ └─### This heading is okay 
       │ ├─##   [7m(no name)[27m
       │ └─## This last heading is okay 
-      └─## This heading is okay 
+    Message <cliMessage>
+      ────────────────────────────────────────────────────────────────────────────────
+
+# duplciate reporting works [plain]
+
+    Code
+      expect_equal(sum(loop$validate_headings()), 4L)
+    Message <cliMessage>
+      ! All headings must have unique IDs.
+      -- Heading structure -----------------------------------------------------------
+    Output
+      # Lesson: "Looping Over Data Sets" 
+      +-## Use a for loop to process files given a list of their names. 
+      +-## Use glob.glob to find sets of files whose names match a pattern. 
+      +-## Use glob and for to process batches of files. 
+      +-## Determining Matches 
+      +-## Solution  (duplicated)
+      +-## Minimum File Size 
+      +-## Solution  (duplicated)
+      +-## Comparing Data 
+      \-## Solution  (duplicated)
+        \-### ZNK test links and images 
+    Message <cliMessage>
+      --------------------------------------------------------------------------------
+
+# duplciate reporting works [ansi]
+
+    Code
+      expect_equal(sum(loop$validate_headings()), 4L)
+    Message <cliMessage>
+      [33m![39m All headings must have unique IDs.
+      -- Heading structure -----------------------------------------------------------
+    Output
+      # Lesson: "Looping Over Data Sets" 
+      +-## Use a for loop to process files given a list of their names. 
+      +-## Use glob.glob to find sets of files whose names match a pattern. 
+      +-## Use glob and for to process batches of files. 
+      +-## Determining Matches 
+      +-## Solution  [7m(duplicated)[27m
+      +-## Minimum File Size 
+      +-## Solution  [7m(duplicated)[27m
+      +-## Comparing Data 
+      \-## Solution  [7m(duplicated)[27m
+        \-### ZNK test links and images 
+    Message <cliMessage>
+      --------------------------------------------------------------------------------
+
+# duplciate reporting works [unicode]
+
+    Code
+      expect_equal(sum(loop$validate_headings()), 4L)
+    Message <cliMessage>
+      ! All headings must have unique IDs.
+      ── Heading structure ───────────────────────────────────────────────────────────
+    Output
+      # Lesson: "Looping Over Data Sets" 
+      ├─## Use a for loop to process files given a list of their names. 
+      ├─## Use glob.glob to find sets of files whose names match a pattern. 
+      ├─## Use glob and for to process batches of files. 
+      ├─## Determining Matches 
+      ├─## Solution  (duplicated)
+      ├─## Minimum File Size 
+      ├─## Solution  (duplicated)
+      ├─## Comparing Data 
+      └─## Solution  (duplicated)
+        └─### ZNK test links and images 
+    Message <cliMessage>
+      ────────────────────────────────────────────────────────────────────────────────
+
+# duplciate reporting works [fancy]
+
+    Code
+      expect_equal(sum(loop$validate_headings()), 4L)
+    Message <cliMessage>
+      [33m![39m All headings must have unique IDs.
+      ── Heading structure ───────────────────────────────────────────────────────────
+    Output
+      # Lesson: "Looping Over Data Sets" 
+      ├─## Use a for loop to process files given a list of their names. 
+      ├─## Use glob.glob to find sets of files whose names match a pattern. 
+      ├─## Use glob and for to process batches of files. 
+      ├─## Determining Matches 
+      ├─## Solution  [7m(duplicated)[27m
+      ├─## Minimum File Size 
+      ├─## Solution  [7m(duplicated)[27m
+      ├─## Comparing Data 
+      └─## Solution  [7m(duplicated)[27m
+        └─### ZNK test links and images 
     Message <cliMessage>
       ────────────────────────────────────────────────────────────────────────────────
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -1,5 +1,6 @@
-vh <- Episode$new(test_path("examples/validation-headings.md"))
-withr::defer(rm("vh"))
+vh   <- Episode$new(test_path("examples/validation-headings.md"))
+loop <- Episode$new(file.path(lesson_fragment(), "_episodes", "14-looping-data-sets.md"))
+withr::defer(rm(list = c("vh", "loop")))
 
 test_that("invalid headings can be caught without the reporters", {
   expect_silent(res <- vh$validate_headings(verbose = FALSE))
@@ -9,6 +10,7 @@ test_that("invalid headings can be caught without the reporters", {
 test_that("reporters will work without CLI", {
   withr::with_options(list("pegboard.no-cli" = TRUE), {
     expect_snapshot(expect_false(all(vh$validate_headings())))
+    expect_snapshot(expect_equal(sum(loop$validate_headings()), 4L))
   })
 })
 
@@ -16,6 +18,9 @@ if (requireNamespace("cli", quietly = TRUE)) {
   cli::test_that_cli("reporters will work", {
     expect_snapshot(expect_false(all(vh$validate_headings())))
   })
-}
 
+  cli::test_that_cli("duplciate reporting works", {
+    expect_snapshot(expect_equal(sum(loop$validate_headings()), 4L))
+  })
+}
 


### PR DESCRIPTION
There was a tricky situation because {cli} assumed the tree to be
unordered, so any sub-headings of duplicate headings would be masked if
they were lower on the tree than previously duplicated headings.

This introduces a partial fix for this issue, but it will pop up again
if there are multiple duplicate headings with an equal number of
subheadings.
