### PR TITLE
validator: validate that links are informative

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9020
+Version: 0.0.0.9021
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pegboard 0.0.0.9021
+
+## NEW FEATURES
+
+- Link validation now checks for more general uninformative link text and empty
+  links (@zkamvar, #49)
+
 # pegboard 0.0.0.9020
 
 ## NEW FEATURES

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -445,12 +445,16 @@ Episode <- R6::R6Class("Episode",
     
     #' @description perform validation on links and images in a document.
     #'
-    #' This will validate the following aspects of links
+    #' This will validate the following aspects of links. See [validate_links()]
+    #' for details.
     #'
-    #'  - use HTTPS protocol
-    #'  - images have alt text
-    #'  - local links are reachable
-    #'  - \[future\] outside links are reachable
+    #'  - External links use HTTPS (`enforce_https`)
+    #'  - Internal links exist (`internal_okay`)
+    #'  - External links are reachable (`all_reachable`) (planned)
+    #'  - Images have alt text (`img_alt_text`)
+    #'  - Link text is descriptive (`descriptive`)
+    #'  - Link text is more than a single letter (`link_length`)
+    #'
     #' @param verbose if `TRUE` (default), a message for each rule broken will
     #'   be issued to the stderr. if `FALSE`, this will be silent. 
     #' @return a logical `TRUE` for valid links and `FALSE` for invalid 

--- a/R/Lesson.R
+++ b/R/Lesson.R
@@ -174,7 +174,17 @@ Lesson <- R6::R6Class("Lesson",
     },
 
     #' @description
-    #' Validate that the heading elements meet minimum accessibility requirements
+    #' Validate that the heading elements meet minimum accessibility 
+    #' requirements. See the internal [validate_headings()] for deails.
+    #'
+    #' This will validate the following aspects of all headings:
+    #'
+    #'  - first heading starts at level 2 (`first_heading_is_second_level`)
+    #'  - greater than level 1 (`all_are_greater_than_first_level`)
+    #'  - increse sequentially (e.g. no jumps from 2 to 4) (`all_are_sequential`)
+    #'  - have names (`all_have_names`)
+    #'  - unique in their own hierarchy (`all_are_unique`)
+    #'
     #' @param verbose if `TRUE`, the heading tree will be printed to the console
     #'   with any warnings assocated with the validators
     #' @return a wide data frame with five rows and the number of columns equal
@@ -191,7 +201,8 @@ Lesson <- R6::R6Class("Lesson",
       res
     },
     #' @description
-    #' Validate that the links and images are valid and accessible
+    #' Validate that the links and images are valid and accessible. See the
+    #' internal [validate_links()] for details.
     #' 
     #' ## Validation variables
     #'
@@ -200,6 +211,7 @@ Lesson <- R6::R6Class("Lesson",
     #'  - External links are reachable (`all_reachable`) (planned)
     #'  - Images have alt text (`img_alt_text`)
     #'  - Link text is descriptive (`descriptive`)
+    #'  - Link text is more than a single letter (`link_length`)
     #'
     #' @param verbose if `TRUE` (default), Any failed tests will be printed to
     #'   the console as a message giving information of where in the document
@@ -208,8 +220,6 @@ Lesson <- R6::R6Class("Lesson",
     #'   to the number of episodes in the lesson with an extra column indicating
     #'   the type of validation. See the same method in the [Episode] class for 
     #'   details.
-    #' @seealso internal functions [validate_links()] and [validate_headings()]
-    #'   for details.
     #' @examples
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_links()

--- a/R/validate_links.R
+++ b/R/validate_links.R
@@ -81,6 +81,7 @@ validate_known_rot <- function(lt, path, verbose = TRUE, cli = TRUE) {
 }
 
 validate_descriptive <- function(lt, path, verbose = TRUE, cli = TRUE) {
+  # NOTE: invalidate "here" links as well
   res <- !any(bad <- tolower(lt$text) %in% c("link", "this link", "a link"))
   if (verbose && !res) {
     just_link    <- lt[bad, , drop = FALSE]

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -769,12 +769,15 @@ loop$validate_headings()
 \subsection{Method \code{validate_links()}}{
 perform validation on links and images in a document.
 
-This will validate the following aspects of links
+This will validate the following aspects of links. See \code{\link[=validate_links]{validate_links()}}
+for details.
 \itemize{
-\item use HTTPS protocol
-\item images have alt text
-\item local links are reachable
-\item [future] outside links are reachable
+\item External links use HTTPS (\code{enforce_https})
+\item Internal links exist (\code{internal_okay})
+\item External links are reachable (\code{all_reachable}) (planned)
+\item Images have alt text (\code{img_alt_text})
+\item Link text is descriptive (\code{descriptive})
+\item Link text is more than a single letter (\code{link_length})
 }
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Episode$validate_links(verbose = TRUE)}\if{html}{\out{</div>}}

--- a/man/Lesson.Rd
+++ b/man/Lesson.Rd
@@ -58,10 +58,6 @@ frg$validate_headings()
 frg <- Lesson$new(lesson_fragment())
 frg$validate_links()
 }
-\seealso{
-internal functions \code{\link[=validate_links]{validate_links()}} and \code{\link[=validate_headings]{validate_headings()}}
-for details.
-}
 \section{Public fields}{
 \if{html}{\out{<div class="r6-fields">}}
 \describe{
@@ -303,7 +299,17 @@ frg$isolate_blocks()$body # only one challenge block_quote
 \if{html}{\out{<a id="method-validate_headings"></a>}}
 \if{latex}{\out{\hypertarget{method-validate_headings}{}}}
 \subsection{Method \code{validate_headings()}}{
-Validate that the heading elements meet minimum accessibility requirements
+Validate that the heading elements meet minimum accessibility
+requirements. See the internal \code{\link[=validate_headings]{validate_headings()}} for deails.
+
+This will validate the following aspects of all headings:
+\itemize{
+\item first heading starts at level 2 (\code{first_heading_is_second_level})
+\item greater than level 1 (\code{all_are_greater_than_first_level})
+\item increse sequentially (e.g. no jumps from 2 to 4) (\code{all_are_sequential})
+\item have names (\code{all_have_names})
+\item unique in their own hierarchy (\code{all_are_unique})
+}
 \subsection{Usage}{
 \if{html}{\out{<div class="r">}}\preformatted{Lesson$validate_headings(verbose = TRUE)}\if{html}{\out{</div>}}
 }
@@ -335,7 +341,8 @@ frg$validate_headings()
 \if{html}{\out{<a id="method-validate_links"></a>}}
 \if{latex}{\out{\hypertarget{method-validate_links}{}}}
 \subsection{Method \code{validate_links()}}{
-Validate that the links and images are valid and accessible
+Validate that the links and images are valid and accessible. See the
+internal \code{\link[=validate_links]{validate_links()}} for details.
 \subsection{Validation variables}{
 \itemize{
 \item External links use HTTPS (\code{enforce_https})
@@ -343,6 +350,7 @@ Validate that the links and images are valid and accessible
 \item External links are reachable (\code{all_reachable}) (planned)
 \item Images have alt text (\code{img_alt_text})
 \item Link text is descriptive (\code{descriptive})
+\item Link text is more than a single letter (\code{link_length})
 }
 }
 \subsection{Usage}{

--- a/man/validate_links.Rd
+++ b/man/validate_links.Rd
@@ -20,6 +20,10 @@ documents. This will include links to images and will respect robots.txt for
 websites.
 }
 \details{
+\subsection{Link Validity}{
+
+All links must resolve to a specific location. If it does not exist, then the
+link is invalid.
 \subsection{External links}{
 
 These links must start with a valid and secure protocol. This means that we
@@ -39,18 +43,34 @@ Anchors are located at the end of URLs that start with a \verb{#} sign. These ar
 used to indicate a section of the documenation.
 }
 
+}
+
+\subsection{Accessibility (a11y)}{
+
+Accessibillity ensures that your links are accurate and descriptive for
+people who have slow connections or use screen reader technology.
 \subsection{Alt-text (for images)}{
 
 All images must have associated alt-text. In pandoc, this is acheived by
 writing the \code{alt} attribute in curly braces after the image:
-\verb{![image caption](link)\{alt='alt text'\}}
+\verb{![image caption](link)\{alt='alt text'\}}:
+\url{https://webaim.org/techniques/alttext/}
 }
 
 \subsection{Descriptive text}{
 
 All links must have descriptive text associated with them, which is
 beneficial for screen readers scanning the links on a page to not have a
-list full of "link", "link", "link".
+list full of "link", "link", "link":
+\url{https://webaim.org/techniques/hypertext/link_text#uninformative}
+}
+
+\subsection{Text length}{
+
+Link text length must be greater than 1:
+\url{https://webaim.org/techniques/hypertext/link_text#link_length}
+}
+
 }
 }
 \note{

--- a/tests/testthat/_snaps/Lesson.md
+++ b/tests/testthat/_snaps/Lesson.md
@@ -63,11 +63,11 @@
     Code
       vlink <- frg$validate_links()
     Message <cliMessage>
-      ! Images need alt-text:
-      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
-      ../no-workie.svg (14-looping-data-sets.md:197)
       ! These files do not exist in the lesson:
       ../no-workie.svg (14-looping-data-sets.md:191)
+      ../no-workie.svg (14-looping-data-sets.md:197)
+      ! Images need alt-text:
+      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
       ../no-workie.svg (14-looping-data-sets.md:197)
 
 # Lessons can be validated [ansi]
@@ -135,11 +135,11 @@
     Code
       vlink <- frg$validate_links()
     Message <cliMessage>
-      [33m![39m Images need alt-text:
-      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
-      ../no-workie.svg (14-looping-data-sets.md:197)
       [33m![39m These files do not exist in the lesson:
       ../no-workie.svg (14-looping-data-sets.md:191)
+      ../no-workie.svg (14-looping-data-sets.md:197)
+      [33m![39m Images need alt-text:
+      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
       ../no-workie.svg (14-looping-data-sets.md:197)
 
 # Lessons can be validated [unicode]
@@ -207,11 +207,11 @@
     Code
       vlink <- frg$validate_links()
     Message <cliMessage>
-      ! Images need alt-text:
-      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
-      ../no-workie.svg (14-looping-data-sets.md:197)
       ! These files do not exist in the lesson:
       ../no-workie.svg (14-looping-data-sets.md:191)
+      ../no-workie.svg (14-looping-data-sets.md:197)
+      ! Images need alt-text:
+      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
       ../no-workie.svg (14-looping-data-sets.md:197)
 
 # Lessons can be validated [fancy]
@@ -279,10 +279,10 @@
     Code
       vlink <- frg$validate_links()
     Message <cliMessage>
-      [33m![39m Images need alt-text:
-      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
-      ../no-workie.svg (14-looping-data-sets.md:197)
       [33m![39m These files do not exist in the lesson:
       ../no-workie.svg (14-looping-data-sets.md:191)
+      ../no-workie.svg (14-looping-data-sets.md:197)
+      [33m![39m Images need alt-text:
+      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
       ../no-workie.svg (14-looping-data-sets.md:197)
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -47,13 +47,13 @@
 ---
 
     Code
-      expect_equal(sum(loop$validate_links()), 3L)
+      expect_equal(sum(loop$validate_links()), 4L)
     Message <simpleMessage>
-      ! Images need alt-text:
-      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
-      ../no-workie.svg (14-looping-data-sets.md:197)
       ! These files do not exist in the lesson:
               ../no-workie.svg (14-looping-data-sets.md:191)
+      ../no-workie.svg (14-looping-data-sets.md:197)
+      ! Images need alt-text:
+      https://carpentries.org/assets/img/TheCarpentries.svg (14-looping-data-sets.md:195)
       ../no-workie.svg (14-looping-data-sets.md:197)
 
 ---
@@ -61,9 +61,6 @@
     Code
       expect_equal(sum(link$validate_links()), 2L)
     Message <simpleMessage>
-      ! Link text should be more descriptive than 'link':
-            'link' (link-test.md:18)
-      'this link' (link-test.md:18)
       ! Links must use HTTPS, not HTTP:
             http://example.com (link-test.md:42)
       ! The following anchors do not exist in the file:
@@ -72,6 +69,32 @@
               [should be a relative link](rel-image) -> [should be a relative link][rel-image] (link-test.md:37)
       ! These files do not exist in the lesson:
               incorrect-link.html (link-test.md:29)
+      ! Avoid uninformative link phrases:
+            <https://webaim.org/techniques/hypertext/link_text#uninformative>
+            'link' (link-test.md:18)
+      'this link' (link-test.md:18)
+      'this' (link-test.md:50)
+      'link' (link-test.md:51)
+      'this link' (link-test.md:52)
+      'a link' (link-test.md:53)
+      'link to' (link-test.md:54)
+      'here' (link-test.md:55)
+      'here for' (link-test.md:56)
+      'click here for' (link-test.md:57)
+      'over here for' (link-test.md:58)
+      'more' (link-test.md:59)
+      'more about' (link-test.md:60)
+      'for more about' (link-test.md:61)
+      'for more info about' (link-test.md:62)
+      'for more information about' (link-test.md:63)
+      'read more about' (link-test.md:64)
+      'read more' (link-test.md:65)
+      'read on' (link-test.md:66)
+      'read on about' (link-test.md:67)
+      ! Avoid single-letter or missing link text:
+            <https://webaim.org/techniques/hypertext/link_text#link_length>
+            'a' (link-test.md:68)
+      '' (link-test.md:69)
 
 # headings reporters will work [plain]
 
@@ -267,9 +290,6 @@
     Code
       expect_equal(sum(link$validate_links()), 2L)
     Message <cliMessage>
-      ! Link text should be more descriptive than 'link':
-      'link' (link-test.md:18)
-      'this link' (link-test.md:18)
       ! Links must use HTTPS, not HTTP:
       http://example.com (link-test.md:42)
       ! The following anchors do not exist in the file:
@@ -278,6 +298,32 @@
       [should be a relative link](rel-image) -> [should be a relative link][rel-image] (link-test.md:37)
       ! These files do not exist in the lesson:
       incorrect-link.html (link-test.md:29)
+      ! Avoid uninformative link phrases:
+      <https://webaim.org/techniques/hypertext/link_text#uninformative>
+      'link' (link-test.md:18)
+      'this link' (link-test.md:18)
+      'this' (link-test.md:50)
+      'link' (link-test.md:51)
+      'this link' (link-test.md:52)
+      'a link' (link-test.md:53)
+      'link to' (link-test.md:54)
+      'here' (link-test.md:55)
+      'here for' (link-test.md:56)
+      'click here for' (link-test.md:57)
+      'over here for' (link-test.md:58)
+      'more' (link-test.md:59)
+      'more about' (link-test.md:60)
+      'for more about' (link-test.md:61)
+      'for more info about' (link-test.md:62)
+      'for more information about' (link-test.md:63)
+      'read more about' (link-test.md:64)
+      'read more' (link-test.md:65)
+      'read on' (link-test.md:66)
+      'read on about' (link-test.md:67)
+      ! Avoid single-letter or missing link text:
+      <https://webaim.org/techniques/hypertext/link_text#link_length>
+      'a' (link-test.md:68)
+      '' (link-test.md:69)
 
 # links reporters will work [ansi]
 
@@ -293,9 +339,6 @@
     Code
       expect_equal(sum(link$validate_links()), 2L)
     Message <cliMessage>
-      [33m![39m Link text should be more descriptive than 'link':
-      'link' (link-test.md:18)
-      'this link' (link-test.md:18)
       [33m![39m Links must use HTTPS, not HTTP:
       http://example.com (link-test.md:42)
       [33m![39m The following anchors do not exist in the file:
@@ -304,6 +347,32 @@
       [should be a relative link](rel-image) -> [should be a relative link][rel-image] (link-test.md:37)
       [33m![39m These files do not exist in the lesson:
       incorrect-link.html (link-test.md:29)
+      [33m![39m Avoid uninformative link phrases:
+      <https://webaim.org/techniques/hypertext/link_text#uninformative>
+      'link' (link-test.md:18)
+      'this link' (link-test.md:18)
+      'this' (link-test.md:50)
+      'link' (link-test.md:51)
+      'this link' (link-test.md:52)
+      'a link' (link-test.md:53)
+      'link to' (link-test.md:54)
+      'here' (link-test.md:55)
+      'here for' (link-test.md:56)
+      'click here for' (link-test.md:57)
+      'over here for' (link-test.md:58)
+      'more' (link-test.md:59)
+      'more about' (link-test.md:60)
+      'for more about' (link-test.md:61)
+      'for more info about' (link-test.md:62)
+      'for more information about' (link-test.md:63)
+      'read more about' (link-test.md:64)
+      'read more' (link-test.md:65)
+      'read on' (link-test.md:66)
+      'read on about' (link-test.md:67)
+      [33m![39m Avoid single-letter or missing link text:
+      <https://webaim.org/techniques/hypertext/link_text#link_length>
+      'a' (link-test.md:68)
+      '' (link-test.md:69)
 
 # links reporters will work [unicode]
 
@@ -319,9 +388,6 @@
     Code
       expect_equal(sum(link$validate_links()), 2L)
     Message <cliMessage>
-      ! Link text should be more descriptive than 'link':
-      'link' (link-test.md:18)
-      'this link' (link-test.md:18)
       ! Links must use HTTPS, not HTTP:
       http://example.com (link-test.md:42)
       ! The following anchors do not exist in the file:
@@ -330,6 +396,32 @@
       [should be a relative link](rel-image) -> [should be a relative link][rel-image] (link-test.md:37)
       ! These files do not exist in the lesson:
       incorrect-link.html (link-test.md:29)
+      ! Avoid uninformative link phrases:
+      <https://webaim.org/techniques/hypertext/link_text#uninformative>
+      'link' (link-test.md:18)
+      'this link' (link-test.md:18)
+      'this' (link-test.md:50)
+      'link' (link-test.md:51)
+      'this link' (link-test.md:52)
+      'a link' (link-test.md:53)
+      'link to' (link-test.md:54)
+      'here' (link-test.md:55)
+      'here for' (link-test.md:56)
+      'click here for' (link-test.md:57)
+      'over here for' (link-test.md:58)
+      'more' (link-test.md:59)
+      'more about' (link-test.md:60)
+      'for more about' (link-test.md:61)
+      'for more info about' (link-test.md:62)
+      'for more information about' (link-test.md:63)
+      'read more about' (link-test.md:64)
+      'read more' (link-test.md:65)
+      'read on' (link-test.md:66)
+      'read on about' (link-test.md:67)
+      ! Avoid single-letter or missing link text:
+      <https://webaim.org/techniques/hypertext/link_text#link_length>
+      'a' (link-test.md:68)
+      '' (link-test.md:69)
 
 # links reporters will work [fancy]
 
@@ -345,9 +437,6 @@
     Code
       expect_equal(sum(link$validate_links()), 2L)
     Message <cliMessage>
-      [33m![39m Link text should be more descriptive than 'link':
-      'link' (link-test.md:18)
-      'this link' (link-test.md:18)
       [33m![39m Links must use HTTPS, not HTTP:
       http://example.com (link-test.md:42)
       [33m![39m The following anchors do not exist in the file:
@@ -356,4 +445,30 @@
       [should be a relative link](rel-image) -> [should be a relative link][rel-image] (link-test.md:37)
       [33m![39m These files do not exist in the lesson:
       incorrect-link.html (link-test.md:29)
+      [33m![39m Avoid uninformative link phrases:
+      <https://webaim.org/techniques/hypertext/link_text#uninformative>
+      'link' (link-test.md:18)
+      'this link' (link-test.md:18)
+      'this' (link-test.md:50)
+      'link' (link-test.md:51)
+      'this link' (link-test.md:52)
+      'a link' (link-test.md:53)
+      'link to' (link-test.md:54)
+      'here' (link-test.md:55)
+      'here for' (link-test.md:56)
+      'click here for' (link-test.md:57)
+      'over here for' (link-test.md:58)
+      'more' (link-test.md:59)
+      'more about' (link-test.md:60)
+      'for more about' (link-test.md:61)
+      'for more info about' (link-test.md:62)
+      'for more information about' (link-test.md:63)
+      'read more about' (link-test.md:64)
+      'read more' (link-test.md:65)
+      'read on' (link-test.md:66)
+      'read on about' (link-test.md:67)
+      [33m![39m Avoid single-letter or missing link text:
+      <https://webaim.org/techniques/hypertext/link_text#link_length>
+      'a' (link-test.md:68)
+      '' (link-test.md:69)
 

--- a/tests/testthat/examples/link-test.md
+++ b/tests/testthat/examples/link-test.md
@@ -41,6 +41,35 @@ This link [is a relative link that works][rel-image]
 
 This [link uses http, which is no bueno](http://example.com)
 
+## Link text
+
+If we have [link text that is informative](https://example.com/link-text#good),
+it will pass.
+
+If we have links like 
+[this][bad-link-text]
+[link][bad-link-text]
+[this link][bad-link-text]
+[a link][bad-link-text]
+[link to][bad-link-text]
+[here][bad-link-text]
+[here for][bad-link-text]
+[click here for][bad-link-text]
+[over here for][bad-link-text]
+[more][bad-link-text]
+[more about][bad-link-text]
+[for more about][bad-link-text]
+[for more info about][bad-link-text]
+[for more information about][bad-link-text]
+[read more about][bad-link-text]
+[read more][bad-link-text]
+[read on][bad-link-text]
+[read on about][bad-link-text],
+[a][bad-link-text],
+[][bad-link-text]
+they will fail.
+
 
 [rel-label-1]: #label-1
 [rel-image]: image-test.html
+[bad-link-text]: https://example.com/link-text#bad

--- a/tests/testthat/test-Lesson.R
+++ b/tests/testthat/test-Lesson.R
@@ -37,7 +37,7 @@ if (requireNamespace("cli")) {
     expect_snapshot(vhead <- frg$validate_headings())
     expect_equal(colSums(vhead[-1]), c(5, 4, 4, 5), ignore_attr = TRUE)
     expect_snapshot(vlink <- frg$validate_links())
-    expect_equal(colSums(vlink[-1]), c(5, 5, 3, 5), ignore_attr = TRUE)
+    expect_equal(colSums(vlink[-1]), c(6, 6, 4, 6), ignore_attr = TRUE)
   })
 }
 
@@ -45,7 +45,7 @@ test_that("Lessons can be _quietly_ validated", {
   expect_silent(vhead <- frg$validate_headings(verbose = FALSE))
   expect_equal(colSums(vhead[-1]), c(5, 4, 4, 5), ignore_attr = TRUE)
   expect_silent(vlink <- frg$validate_links(verbose = FALSE))
-  expect_equal(colSums(vlink[-1]), c(5, 5, 3, 5), ignore_attr = TRUE)
+  expect_equal(colSums(vlink[-1]), c(6, 6, 4, 6), ignore_attr = TRUE)
 })
 
 test_that("Lesson class can get the challenges", {

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -26,7 +26,7 @@ test_that("links reporters will work without CLI", {
 
   withr::with_options(list("pegboard.no-cli" = TRUE), {
     expect_snapshot(expect_false(all(cats$validate_links())))
-    expect_snapshot(expect_equal(sum(loop$validate_links()), 3L))
+    expect_snapshot(expect_equal(sum(loop$validate_links()), 4L))
     expect_snapshot(expect_equal(sum(link$validate_links()), 2L))
   })
 


### PR DESCRIPTION
This will report on [links that are not informative](https://webaim.org/techniques/hypertext/link_text#uninformative).

The tests show the kind of links we are searching for:

https://github.com/carpentries/pegboard/pull/49/files#diff-69e2ec1949803047b18d919bf498dae601a54ad7083006d8fcd7795f30d367e9R44-R71