### PR TITLE
Add feature to auto-convert to automatically recognize sandpaper lessons when jekyll = FALSE

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9021
+Version: 0.0.0.9022
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,7 +48,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1.9001
+RoxygenNote: 7.1.2
 URL: https://github.com/zkamvar/pegboard
 BugReports: https://github.com/zkamvar/pegboard/issues
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
   attempt to label divs in the episode (with a warning if there is no success).
 - The `Lesson` class will now run the `$confirm_sandpaper()` method for all
   markdown files if `jekyll = FALSE`. 
+- `Lesson$new()` will now default to the current working directory.
 
 ## MISC
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,17 @@
+# pegboard 0.0.0.9022
+
+## NEW FEATURES
+
+- The `Episode` class now gains the `$confirm_sandpaper()` method to bypass the
+  assumption that all Episodes start as kramdown-formatted documents and will
+  attempt to label divs in the episode (with a warning if there is no success).
+- The `Lesson` class will now run the `$confirm_sandpaper()` method for all
+  markdown files if `jekyll = FALSE`. 
+
+## MISC
+
+- The internal `get_list_block()` will no longer auto-label divs. 
+
 # pegboard 0.0.0.9021
 
 ## NEW FEATURES

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -78,6 +78,29 @@ Episode <- R6::R6Class("Episode",
     },
 
 
+    #' @description enforce that the episode is a {sandpaper} episode withtout
+    #' going through the conversion steps. The default Episodes from pegboard
+    #' were assumed to be generated using Jekyll with kramdown syntax. This is
+    #' a bit of a kludge to bypass the normal checks for kramdown syntax and 
+    #' just assume pandoc syntax
+    confirm_sandpaper = function() {
+      ok <- c("unblock", "use_sandpaper_md", "use_sandpaper_rmd",
+        "move_questions", "move_objectives", "move_keypoints")
+      muts <- private$mutations
+      muts[ok] <- TRUE
+      private$mutations <- muts
+      invisible(
+        tryCatch(self$label_divs(),
+          error = function(e) {
+            msg <- glue::glue("
+              {e$message}
+              Section (div) tags for {self$name} will not be labelled"
+            )
+            warning(msg, call. = FALSE)
+            self
+          })
+      )
+    },
     #' @description return all `block_quote` elements within the Episode
     #' @param type the type of block quote in the Jekyll syntax like ".challenge",
     #'   ".discussion", or ".solution"
@@ -111,7 +134,6 @@ Episode <- R6::R6Class("Episode",
     get_blocks = function(type = NULL, level = 1L) {
       get_blocks(self$body, type = type, level = level)
     },
-
     #' @description
     #' fetch the image sources and optionally process them for easier parsing.
     #' The default version of this function is equivalent to the active binding
@@ -129,7 +151,6 @@ Episode <- R6::R6Class("Episode",
     get_images = function(process = FALSE) {
       get_images(self, process = process)
     },
-
     #' @description
     #' label all the div elements within the Episode to extract them with 
     #' `$get_divs()`
@@ -137,7 +158,6 @@ Episode <- R6::R6Class("Episode",
       label_div_tags(self)
       return(invisible(self))
     },
-    
     #' @description
     #' return all div elements within the Episode
     #' @param type the type of div tag (e.g. 'challenge' or 'solution')
@@ -147,13 +167,11 @@ Episode <- R6::R6Class("Episode",
     get_divs = function(type = NULL, include = FALSE) {
       get_divs(self$body, type = type, include = include)
     },
-
     #' @description
     #' Extract the yaml metadata from the episode
     get_yaml = function() {
       yaml::yaml.load(self$yaml)
     },
-    
     #' @description
     #' Ammend or add a setup code block to use `{dovetail}`
     #' 
@@ -176,7 +194,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['use_dovetail'] <- TRUE
       invisible(self)
     },
-
     #' @description
     #' Use the sandpaper package for processing
     #'
@@ -204,7 +221,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations[type] <- TRUE
       invisible(self)
     },
-
     #' @description
     #' Remove error blocks
     remove_error = function() {
@@ -215,7 +231,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['remove_error'] <- TRUE
       invisible(self)
     },
-    
     #' @description
     #' Remove output blocks
     remove_output = function() {
@@ -226,7 +241,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['remove_output'] <- TRUE
       invisible(self)
     },
-    
     #' @description 
     #' move the objectives yaml item to the body
     move_objectives = function() {
@@ -240,7 +254,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['move_objectives'] <- TRUE
       invisible(self)
     },
-    
     #' @description 
     #' move the keypoints yaml item to the body
     move_keypoints = function() {
@@ -254,7 +267,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['move_keypoints'] <- TRUE
       invisible(self)
     },
-
     #' @description 
     #' move the questions yaml item to the body
     move_questions = function() {
@@ -268,7 +280,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['move_questions'] <- TRUE
       invisible(self)
     },
-
     #' @description
     #' Create a graph of the top-level elements for the challenges.
     #'
@@ -292,7 +303,6 @@ Episode <- R6::R6Class("Episode",
     get_challenge_graph = function(recurse = TRUE) {
       purrr::map_dfr(self$challenges, feature_graph, recurse = recurse, .id = "Block")
     },
-
     #' @description show the markdown contents on the screen
     #' @return a character vector with one line for each line of output
     #' @examples
@@ -303,21 +313,18 @@ Episode <- R6::R6Class("Episode",
     show = function() {
       super$show(get_stylesheet())
     },
-
     #' @description show the first n lines of markdown contents on the screen
     #' @param n the number of lines to show from the top 
     #' @return a character vector with one line for each line of output
     head = function(n = 6L) {
       super$head(n, get_stylesheet())
     },
-
     #' @description show the first n lines of markdown contents on the screen
     #' @param n the number of lines to show from the top 
     #' @return a character vector with one line for each line of output
     tail = function(n = 6L) {
       super$tail(n, get_stylesheet())
     },
-
     #' @description write the episode to disk as markdown
     #'
     #' @param path the path to write your file to. Defaults to an empty
@@ -360,7 +367,6 @@ Episode <- R6::R6Class("Episode",
       # nocov end
       return(invisible(self))
     },
-
     #' @description
     #' Re-read episode from disk
     #' @return the episode object
@@ -376,7 +382,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations <- private$mutations & FALSE
       return(invisible(self))
     },
-
     #' @description
     #' Remove all elements except for those within block quotes that have a
     #' kramdown tag. Note that this is a destructive process.
@@ -393,7 +398,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['isolate_blocks'] <- TRUE
       invisible(self)
     },
-
     #' @description convert challenge blocks to roxygen-like code blocks
     #' @param token the token to use to indicate non-code, Defaults to "#'"
     #' @return the Episode object, invisibly
@@ -417,7 +421,6 @@ Episode <- R6::R6Class("Episode",
       private$mutations['unblock'] <- TRUE
       invisible(self)
     },
-
     #' @description perform validation on headings in a document.
     #'
     #' This will validate the following aspects of all headings:
@@ -471,43 +474,35 @@ Episode <- R6::R6Class("Episode",
     show_problems = function() {
       private$problems
     },
-
     #' @field headings \[`xml_nodeset`\] all headings in the document
     headings = function() {
       get_headings(self$body)
     },
-
     #' @field links \[`xml_nodeset`\] all links (not images) in the document
     links = function() {
       xpath <- ".//md:link | .//md:text[klink]"
       xml2::xml_find_all(self$body, xpath, self$ns)
     },
-
     #' @field images \[`xml_nodeset`\] all image sources in the document
     images = function() {
       get_images(self, process = FALSE)
     },
-
     #' @field tags \[`xml_nodeset`\] all the kramdown tags from the episode
     tags = function() {
       xml2::xml_find_all(self$body, ".//@ktag")
     },
-
     #' @field questions \[`character`\] the questions from the episode
     questions = function() {
       get_list_block(self, type = "questions", in_yaml = !private$mutations['move_questions'])
     },
-
     #' @field keypoints \[`character`\] the keypoints from the episode
     keypoints = function() {
       get_list_block(self, type = "keypoints", in_yaml = !private$mutations['move_keypoints'])
     },
-
     #' @field objectives \[`character`\] the objectives from the episode
     objectives = function() {
       get_list_block(self, type = "objectives", in_yaml = !private$mutations['move_objectives'])
     },
-
     #' @field challenges \[`xml_nodeset`\] all the challenges blocks from the episode
     challenges = function() {
       if (!private$mutations['unblock']) {
@@ -519,7 +514,6 @@ Episode <- R6::R6Class("Episode",
       }
       get_challenges(self$body, type = type)
     },
-
     #' @field solutions \[`xml_nodeset`\] all the solutions blocks from the episode
     solutions = function() {
       if (!private$mutations['unblock']) {
@@ -531,7 +525,6 @@ Episode <- R6::R6Class("Episode",
       }
       get_solutions(self$body, type = type)
     },
-
     #' @field output \[`xml_nodeset`\] all the output blocks from the episode
     output = function() {
       if (any(private$mutations[c('use_sandpaper_md', 'use_sandpaper_rmd')])) {
@@ -540,7 +533,6 @@ Episode <- R6::R6Class("Episode",
         get_code(self$body, ".output")
       }
     },
-
     #' @field error \[`xml_nodeset`\] all the error blocks from the episode
     error = function() {
       if (any(private$mutations[c('use_sandpaper_md', 'use_sandpaper_rmd')])) {
@@ -549,17 +541,14 @@ Episode <- R6::R6Class("Episode",
         get_code(self$body, ".error")
       }
     },
-
     #' @field code \[`xml_nodeset`\] all the code blocks from the episode
     code = function() {
       get_code(self$body, type = NULL, attr = NULL)
     },
-
     #' @field name \[`character`\] the name of the source file without the path
     name = function() {
       fs::path_file(self$path)
     },
-
     #' @field lesson \[`character`\] the path to the lesson where the episode is from
     lesson = function() {
       lsn <- fs::path_dir(self$path)
@@ -577,11 +566,9 @@ Episode <- R6::R6Class("Episode",
       yml[[what]] <- NULL
       self$yaml <- c("---", strsplit(yaml::as.yaml(yml), "\n")[[1]], "---")
     },
-
     record_problem = function(x) {
       private$problems <- c(private$problems, x)
     },
-
     mutations = c(
       unblock           = FALSE, # have kramdown blocks been converted?
       use_dovetail      = FALSE, # are we keeping challenges in code blocks?
@@ -595,9 +582,7 @@ Episode <- R6::R6Class("Episode",
       remove_output     = FALSE, # have output been removed?
       NULL
     ),
-
     problems = list(),
-
     deep_clone = function(name, value) {
       if (name == "body") {
         xml2::read_xml(as.character(value))

--- a/R/Lesson.R
+++ b/R/Lesson.R
@@ -29,7 +29,8 @@ Lesson <- R6::R6Class("Lesson",
 
     #' @description create a new Lesson object from a directory
     #' @param path \[`character`\] path to a lesson directory. This must have a
-    #'   folder called `_episodes` within that contains markdown episodes
+    #'   folder called `_episodes` within that contains markdown episodes. 
+    #'   Defaults to the current working directory.
     #' @param rmd \[`logical`\] when `TRUE`, the imported files will be the
     #'   source RMarkdown files. Defaults to `FALSE`, which reads the rendered
     #'   markdown files.
@@ -44,15 +45,13 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$path
     #' frg$episodes
-    initialize = function(path = NULL, rmd = FALSE, jekyll = TRUE, ...) {
+    initialize = function(path = ".", rmd = FALSE, jekyll = TRUE, ...) {
       stop_if_no_path(path)
       if (jekyll) {
         jeky <- read_jekyll_episodes(path, rmd, ...)
         self$episodes <- jeky$episodes
         self$rmd <- jeky$rmd
       } else {
-        # Modern lessons do not need to have tags processed because there are 
-        # no tags!!!
         episode_path <- fs::path(path, "episodes")
         extra_paths <- fs::path(path, c("instructors", "learners", "profiles"))
         cfg <- fs::dir_ls(path, regexp = "config[.]ya?ml")

--- a/R/div.R
+++ b/R/div.R
@@ -774,6 +774,7 @@ label_pairs <- function(pairs, n_tags, reverse = FALSE) {
     # Tags that are closed will be labelled with the current tag on the stack
     # and then have the stack decreased
     if (is_closed) {
+      # This will error whenever there are too many closing tags (odd number)
       labels[this_item]   <- tag_stack[this_tag]
       tag_stack[this_tag] <- 0L
       this_tag <- this_tag - 1L

--- a/R/get_lesson.R
+++ b/R/get_lesson.R
@@ -15,8 +15,10 @@
 #' @export
 #' @examples
 #'
-#' png <- get_lesson("swcarpentry/python-novice-gapminder")
-#' str(png, max.level = 1)
+#' if (interactive()) {
+#'   png <- get_lesson("swcarpentry/python-novice-gapminder")
+#'   str(png, max.level = 1)
+#' }
 get_lesson <- function(lesson = NULL, path = tempdir(), overwrite = FALSE, ...) {
   if (!requireNamespace("gert", quietly = FALSE)) {
     stop("Please install the {gert} package to use this feature.")

--- a/R/get_list_block.R
+++ b/R/get_list_block.R
@@ -37,7 +37,7 @@ get_list_block <- function(self, type = "questions", in_yaml = TRUE) {
     q <- strsplit(txt, "\n")[[1]]
   } else {
     # In order to get the divs, we must first ensure that they are labelled
-    q <- get_divs(self$label_divs()$body, type)
+    q <- get_divs(self$body, type)
     if (length(q)) {
       q <- q[[1]]
     } else {

--- a/R/read_jekyll_episodes.R
+++ b/R/read_jekyll_episodes.R
@@ -15,5 +15,5 @@ read_jekyll_episodes <- function(path = NULL, rmd = FALSE, ...) {
     stop(glue::glue("could not find either _episodes/ or _episodes_rmd/ in {path}"))
   }
 
-  return(list(episodes = read_markdown_files(src, ...), rmd = rmd))
+  return(list(episodes = read_markdown_files(src, sandpaper = FALSE, ...), rmd = rmd))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -32,7 +32,7 @@ stop_if_no_path <- function(path) {
   }
 }
 
-read_markdown_files <- function(src, cfg = character(0), ...) {
+read_markdown_files <- function(src, cfg = character(0), sandpaper = TRUE, ...) {
   # Grabbing ONLY the markdown files (there are other sources of detritus)
   the_episodes <- fs::dir_ls(src, glob = "*md")
   the_names    <- fs::path_file(the_episodes)
@@ -53,6 +53,10 @@ read_markdown_files <- function(src, cfg = character(0), ...) {
   }
 
   episodes <- purrr::map(the_episodes, Episode$new, ...)
+  if (sandpaper) {
+    purrr::walk(episodes, ~.x$confirm_sandpaper())
+  }
+
   # Names of the episodes will be the filename, not the basename
   names(episodes) <- the_names
   return(episodes)

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -173,6 +173,7 @@ loop$validate_links()
 \subsection{Public methods}{
 \itemize{
 \item \href{#method-new}{\code{Episode$new()}}
+\item \href{#method-confirm_sandpaper}{\code{Episode$confirm_sandpaper()}}
 \item \href{#method-get_blocks}{\code{Episode$get_blocks()}}
 \item \href{#method-get_images}{\code{Episode$get_images()}}
 \item \href{#method-label_divs}{\code{Episode$label_divs()}}
@@ -256,6 +257,20 @@ scope$challenges
 }
 \if{html}{\out{</div>}}
 
+}
+
+}
+\if{html}{\out{<hr>}}
+\if{html}{\out{<a id="method-confirm_sandpaper"></a>}}
+\if{latex}{\out{\hypertarget{method-confirm_sandpaper}{}}}
+\subsection{Method \code{confirm_sandpaper()}}{
+enforce that the episode is a {sandpaper} episode withtout
+going through the conversion steps. The default Episodes from pegboard
+were assumed to be generated using Jekyll with kramdown syntax. This is
+a bit of a kludge to bypass the normal checks for kramdown syntax and
+just assume pandoc syntax
+\subsection{Usage}{
+\if{html}{\out{<div class="r">}}\preformatted{Episode$confirm_sandpaper()}\if{html}{\out{</div>}}
 }
 
 }

--- a/man/Lesson.Rd
+++ b/man/Lesson.Rd
@@ -108,14 +108,15 @@ files, default is \code{FALSE} for markdown files.}
 \subsection{Method \code{new()}}{
 create a new Lesson object from a directory
 \subsection{Usage}{
-\if{html}{\out{<div class="r">}}\preformatted{Lesson$new(path = NULL, rmd = FALSE, jekyll = TRUE, ...)}\if{html}{\out{</div>}}
+\if{html}{\out{<div class="r">}}\preformatted{Lesson$new(path = ".", rmd = FALSE, jekyll = TRUE, ...)}\if{html}{\out{</div>}}
 }
 
 \subsection{Arguments}{
 \if{html}{\out{<div class="arguments">}}
 \describe{
 \item{\code{path}}{[\code{character}] path to a lesson directory. This must have a
-folder called \verb{_episodes} within that contains markdown episodes}
+folder called \verb{_episodes} within that contains markdown episodes.
+Defaults to the current working directory.}
 
 \item{\code{rmd}}{[\code{logical}] when \code{TRUE}, the imported files will be the
 source RMarkdown files. Defaults to \code{FALSE}, which reads the rendered

--- a/man/get_lesson.Rd
+++ b/man/get_lesson.Rd
@@ -27,6 +27,8 @@ directory and extracts the lesson in \verb{_episodes/} using \code{\link[tinkr:t
 }
 \examples{
 
-png <- get_lesson("swcarpentry/python-novice-gapminder")
-str(png, max.level = 1)
+if (interactive()) {
+  png <- get_lesson("swcarpentry/python-novice-gapminder")
+  str(png, max.level = 1)
+}
 }

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -31,6 +31,23 @@ test_that("Episodes can be created and are valid", {
 
 })
 
+
+test_that("$confirm_sandpaper() does not error on mismatched divs", {
+  e <- Episode$new(test_path("examples", "mismatched-div.txt"), 
+    process_tags = FALSE, fix_links = FALSE, fix_liquid = FALSE)
+  suppressMessages({
+    suppressWarnings({
+      expect_warning(e$confirm_sandpaper(), 
+        "Section (div) tags for mismatched-div.txt will not be labelled",
+        fixed = TRUE
+      ) %>%
+      expect_message("mis-match was detected")
+    })
+  })
+  expect_s3_class(e, "Episode")
+})
+
+
 test_that("Episodes can be reset if needed", {
 
   scope <- fs::path(lesson_fragment(), "_episodes", "17-scope.md")

--- a/tests/testthat/test-Lesson.R
+++ b/tests/testthat/test-Lesson.R
@@ -14,6 +14,9 @@ test_that("Sandpaper lessons can be read", {
   snd <- Lesson$new(path = lesson_fragment("sandpaper-fragment"), jekyll = FALSE)
   expect_s3_class(snd, "Lesson")
   expect_named(snd$episodes, "intro.Rmd")
+  # sandpaper lessons will have their divs pre-labeled.
+  expect_length(snd$challenges()[[1]], 1L)
+  expect_length(snd$solutions()[[1]], 2L)
 })
 
 test_that("Lesson class contains the right stuff", {

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -46,7 +46,8 @@ test_that("lessons can be read from local files", {
 
 test_that("lessons can be downloaded", {
 
-  testthat::skip_if_offline()
+  skip_if_offline()
+  skip_on_os("windows")
   expect_length(fs::dir_ls(d), 0)
   lex <- get_lesson("carpentries/lesson-example", path = d)
   # the output is a Lesson object
@@ -61,7 +62,8 @@ test_that("lessons can be downloaded", {
 
 test_that("lessons are accessed without re-downloading", {
 
-  testthat::skip_if_offline()
+  skip_if_offline()
+  skip_on_os("windows")
 
   # The lesson already exists in the directory
   expect_length(fs::dir_ls(d), 1)
@@ -80,7 +82,8 @@ test_that("lessons are accessed without re-downloading", {
 })
 
 test_that("overwriting is possible", {
-  testthat::skip_if_offline()
+  skip_if_offline()
+  skip_on_os("windows")
 
   expect_length(fs::dir_ls(d), 1)
 
@@ -98,7 +101,8 @@ test_that("overwriting is possible", {
 
 test_that("Lesson flags will be passed down", {
 
-  testthat::skip_if_offline()
+  skip_if_offline()
+  skip_on_os("windows")
 
   # The lesson already exists in the directory
   expect_length(fs::dir_ls(d), 1)
@@ -126,7 +130,8 @@ test_that("Lesson flags will be passed down", {
 
 test_that("Lesson methods work as expected", {
 
-  testthat::skip_if_offline()
+  skip_if_offline()
+  skip_on_os("windows")
 
   # The lesson already exists in the directory
   expect_length(fs::dir_ls(d), 1)
@@ -255,6 +260,9 @@ test_that("Lesson methods work as expected", {
 
 test_that("code with embedded div tags are parsed correctly", {
 
+  skip_if_offline()
+  skip_on_os("windows")
+
   suppressMessages(lex <- get_lesson("carpentries/lesson-example"))
   expect_length(lex$episodes[[4]]$get_blocks(), 12)
   expect_length(lex$episodes[[4]]$unblock()$get_divs(), 15)
@@ -266,6 +274,8 @@ test_that("code with embedded div tags are parsed correctly", {
 test_that("Lessons with Rmd sources can be downloaded", {
 
   skip_if_offline()
+  skip_on_os("windows")
+
   expect_false(fs::dir_exists(fs::path(d, "swcarpentry--r-novice-inflammation")))
 
   expect_message(


### PR DESCRIPTION
One of the user complaints was that their lesson would throw an error at the very end of the build process when they were building the syllabus because they had unbalanced fences. 

The thing is, this wasn't happening when the file was being read in, it was happening when I was querying for the question blocks to insert into the schedule pages, which made the error even more confusing. 

I've updated `Lesson$new(jekyll = FALSE)` to automatically try to run `$label_divs()` and throw the error as a warning if it does not succeed. This way, the lesson can still be built even if it's missing a fence or two, which means that episodes that are still valid will be built and stored in the cache instead of everything going to hell. 

This also adds the Episode method `$confirm_sandpaper()`, which sets a lot of the mutation flags to avoid unnecessary processing to convert kramdown to pandoc