### PR TITLE
Fix setup parser

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9024
+Version: 0.0.0.9025
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pegboard 0.0.0.9025
+
+## BUG FIX
+
+- RMarkdown episodes that had a setup chunk without specifying `includes` are 
+  now considered to have valid setup chunks and can have those chunks converted.
+
 # pegboard 0.0.0.9024
 
 ## NEW FEATURES

--- a/R/use_sandpaper.R
+++ b/R/use_sandpaper.R
@@ -24,7 +24,7 @@ use_sandpaper <- function(body, rmd = TRUE) {
   has_setup_chunk <- xml2::xml_find_lgl(
     body, 
     # setup is the first code block that is not included
-    "boolean(./md:code_block[1][@language='r' and @include='FALSE'])",
+    "boolean(./md:code_block[1][@language='r' and (@name='setup' or @include='FALSE')])",
     get_ns(body)
   )
   if (has_setup_chunk || rmd) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -157,7 +157,7 @@ xml_new_paragraph <- function(text = "", ns, tag = TRUE) {
 #' @keywords internal
 get_setup_chunk <- function(body) {
   ns <- get_ns(body)
-  query <- "./md:code_block[1][@language='r' and @include='FALSE']"
+  query <- "./md:code_block[1][@language='r' and (@name='setup' or @include='FALSE')]"
   setup <- xml2::xml_find_first(body, query, ns)
 
   # No setup chunk from Jekyll site

--- a/inst/rmd-lesson/_episodes_rmd/01-test.Rmd
+++ b/inst/rmd-lesson/_episodes_rmd/01-test.Rmd
@@ -1,0 +1,32 @@
+---
+title: "Intro to Raster Data"
+teaching: 30
+exercises: 20
+questions:
+-  "What is a raster dataset?"
+objectives:
+-  "Describe the fundamental attributes of a raster dataset."
+keypoints:
+- "The GeoTIFF file format includes metadata about the raster data." 
+source: Rmd
+---
+
+```{r setup, echo=FALSE}
+source("../bin/chunk-options.R")
+source("../setup.R") # NB downloads ~180 MB
+knitr_fig_path("01-")
+knitr::opts_chunk$set(fig.height = 6)
+```
+
+```{r load-libraries, echo = FALSE, results='hide', message = FALSE, warning = FALSE}
+library(raster)
+library(rgdal)
+library(ggplot2)
+library(dplyr)
+```
+
+> ## Things You'll Need To Complete This Episode
+>
+> See the [lesson homepage]({{ site.baseurl }}) for detailed information about the software,
+> data, and other prerequisites you will need to work through the examples in this episode.
+{: .prereq}

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -21,6 +21,28 @@ test_that("Episodes with commonmark-violating liquid relative links can be read"
   expect_snapshot(cat(tmp$show(), sep = "\n"))
 })
 
+test_that("Episodes without include=FALSE in setup chunk are still valid", {
+
+  rast <- fs::path(lesson_fragment("rmd-lesson"), "_episodes_rmd", "01-test.Rmd")
+  e <- Episode$new(rast, process_tags = TRUE, fix_links = FALSE)
+  setup <- get_setup_chunk(e$body)
+  # The includes of the setup chunk is NA
+  expect_true(is.na(xml2::xml_attr(setup, "includes")))
+  old_setup_code <- parse(text = xml2::xml_text(setup))
+  expect_length(old_setup_code, 4)
+  expect_match(as.character(old_setup_code)[1], 'bin/chunk-options.R')
+  expect_match(as.character(old_setup_code)[3], 'knitr_fig_path')
+
+  e$use_sandpaper()
+  setup <- get_setup_chunk(e$body)
+  setup_code <- parse(text = xml2::xml_text(setup))
+  expect_true(is.na(xml2::xml_attr(setup, "includes")))
+  expect_length(setup_code, 2)
+  expect_equal(setup_code[1], old_setup_code[2], ignore_attr = TRUE)
+  expect_equal(setup_code[2], old_setup_code[4], ignore_attr = TRUE)
+
+})
+
 
 test_that("Episodes can be converted to use sandpaper", {
 


### PR DESCRIPTION
This fixes a situation pegboard would not detect the below code chunk as a valid setup chunk because it is missing an `include = FALSE` statement. 

````markdown
```{r setup, echo = FALSE}
# setup stuff here
```
````

