### PR TITLE
Auto-detect R Markdown documents in Jekyll lessons

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -9,3 +9,4 @@
 ^appveyor\.yml$
 ^codecov\.yml$
 ^vignettes/
+^_pkgdown\.yml$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9026
+Version: 0.0.0.9027
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pegboard 0.0.0.9027
+
+## NEW FEATURES
+
+ - Jekyll-based lessons will now auto-detect and read in R Markdown content if
+   it exists. The `rmd` flag for the Lesson initializer now does nothing.
+
 # pegboard 0.0.0.9026
 
 ## BUG FIX

--- a/R/read_jekyll_episodes.R
+++ b/R/read_jekyll_episodes.R
@@ -2,18 +2,56 @@ read_jekyll_episodes <- function(path = NULL, rmd = FALSE, ...) {
   # Old Lesson
   md_src  <- fs::path(path, "_episodes")
   rmd_src <- fs::path(path, "_episodes_rmd")
+  # Enforce that we are using RMD files
+  rmd_exists <- fs::dir_exists(rmd_src)
+  md_exists <- fs::dir_exists(md_src)
 
-  if (!rmd && fs::dir_exists(md_src)) {
-    src <- md_src
-  } else if (fs::dir_exists(rmd_src) && (rmd || !fs::dir_exists(md_src))) {
-    if (!rmd) {
-      message("could not find _episodes/, using _episodes_rmd/ as the source")
-      rmd <- TRUE
-    }
-    src <- rmd_src
-  } else {
+  if (!rmd_exists && !md_exists) {
     stop(glue::glue("could not find either _episodes/ or _episodes_rmd/ in {path}"))
   }
 
-  return(list(episodes = read_markdown_files(src, sandpaper = FALSE, ...), rmd = rmd))
+  rmd_files <- if (rmd_exists) fs::dir_ls(rmd_src, glob = "*Rmd") else character(0)
+  md_files  <- if (md_exists) fs::dir_ls(md_src, glob = "*md") else character(0)
+  md_n <- length(md_files)
+  rmd_n <- length(rmd_files)
+  read_rmd <- rmd_n > 0L
+
+  if (read_rmd) {
+    rmd_slugs <- fs::path_ext_remove(fs::path_file(rmd_files))
+    md_slugs  <- fs::path_ext_remove(fs::path_file(md_files))
+    all_rmd   <- md_n == 0L || identical(rmd_slugs, md_slugs)
+    rmd <- TRUE
+  } else {
+    all_rmd <- FALSE
+  }
+
+  read_md <- md_exists && md_n > 0L && !all_rmd
+
+  eps <- list()
+
+  if (read_md) {
+    eps <- read_markdown_files(md_src, sandpaper = FALSE, ...)
+  } else if (md_exists && md_n == 0L) {
+    stop(glue::glue("The _episodes/ directory must have (R)markdown files"),
+      call. = FALSE
+    )
+  } else if (all_rmd) {
+    message("could not find _episodes/, using _episodes_rmd/ as the source")
+  } else {
+    # source directory does not exist, but the rmd does
+  }
+
+  if (read_rmd) {
+    rmd_eps <- read_markdown_files(rmd_src, sandpaper = FALSE, ...)
+    if (!all_rmd) {
+      to_switch <- fs::path_ext_set(rmd_slugs[rmd_slugs %in% md_slugs], "md")
+      new_names <- fs::path_ext_set(to_switch, "Rmd")
+      eps[to_switch] <- rmd_eps[new_names]
+      names(eps) <- unname(purrr::map_chr(eps, "name"))
+    } else {
+      eps <- rmd_eps
+    }
+  }
+
+  return(list(episodes = eps, rmd = rmd))
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -61,7 +61,7 @@ articles:
  - title: "Developer Guides"
    navbar: ~
    contents:
-     - validation
+     - articles/validation
  - title: "Historical Analysis"
    navbar: ~
    contents:

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -55,8 +55,18 @@ test_that("lessons can be downloaded", {
   # the directory exists
   expect_true(fs::dir_exists(fs::path(d, "carpentries--lesson-example", "_episodes")))
   # The episodes in the object are accounted for
-  episodes <- fs::dir_ls(fs::path(d, "carpentries--lesson-example", "_episodes"))
-  expect_equal(episodes, lex$files, ignore_attr = TRUE)
+  episodes <- c(
+    "01-design.md",
+    "02-tooling.md",
+    "03-organization.md",
+    "04-formatting.md",
+    "05-rmarkdown-example.Rmd",
+    "06-style-guide.md",
+    "07-checking.md",
+    "08-coffee.md",
+    NULL # add NULL in case we need to rearrange or add things ;)
+  )
+  expect_named(lex$files, episodes)
 
 })
 
@@ -75,8 +85,18 @@ test_that("lessons are accessed without re-downloading", {
   # the directory exists
   expect_true(fs::dir_exists(fs::path(d, "carpentries--lesson-example", "_episodes")))
   # The episodes in the object are accounted for
-  episodes <- fs::dir_ls(fs::path(d, "carpentries--lesson-example", "_episodes"))
-  expect_equal(episodes, lex$files, ignore_attr = TRUE)
+  episodes <- c(
+    "01-design.md",
+    "02-tooling.md",
+    "03-organization.md",
+    "04-formatting.md",
+    "05-rmarkdown-example.Rmd",
+    "06-style-guide.md",
+    "07-checking.md",
+    "08-coffee.md",
+    NULL # add NULL in case we need to rearrange or add things ;)
+  )
+  expect_named(lex$files, episodes)
 
 
 })
@@ -94,8 +114,18 @@ test_that("overwriting is possible", {
   # the directory exists
   expect_true(fs::dir_exists(fs::path(d, "carpentries--lesson-example", "_episodes")))
   # The episodes in the object are accounted for
-  episodes <- fs::dir_ls(fs::path(d, "carpentries--lesson-example", "_episodes"))
-  expect_equal(episodes, lex$files, ignore_attr = TRUE)
+  episodes <- c(
+    "01-design.md",
+    "02-tooling.md",
+    "03-organization.md",
+    "04-formatting.md",
+    "05-rmarkdown-example.Rmd",
+    "06-style-guide.md",
+    "07-checking.md",
+    "08-coffee.md",
+    NULL # add NULL in case we need to rearrange or add things ;)
+  )
+  expect_named(lex$files, episodes)
 
 })
 
@@ -185,7 +215,7 @@ test_that("Lesson methods work as expected", {
   expect_equal(fs::path_file(fs::path_dir(lex$path)), fs::path_file(d))
 
   # $rmd------------------------------------------------------------------------
-  expect_false(lex$rmd)
+  expect_true(lex$rmd)
 
   # $files ---------------------------------------------------------------------
   episodes <- c(
@@ -193,7 +223,7 @@ test_that("Lesson methods work as expected", {
     "02-tooling.md",
     "03-organization.md",
     "04-formatting.md",
-    "05-rmarkdown-example.md",
+    "05-rmarkdown-example.Rmd",
     "06-style-guide.md",
     "07-checking.md",
     "08-coffee.md",
@@ -280,8 +310,7 @@ test_that("Lessons with Rmd sources can be downloaded", {
 
   expect_message(
     rni <- get_lesson("swcarpentry/r-novice-inflammation", path = d),
-    "could not find _episodes/, using _episodes_rmd/ as the source",
-    fixed = TRUE
+    "could not find _episodes/, using _episodes_rmd/ as the source"
   )
 
   expect_s3_class(rni, "Lesson")


### PR DESCRIPTION
This is a fix that makes working with the dual-source nature of R Markdown-based lessons a bit easier to handle. 