### PR TITLE
remove root and layout yaml items for sandpaper

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.0.0.9031
+Version: 0.0.0.9032
 Authors@R:
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+# pegboard 0.0.0.9032
+
+## BUG FIX
+
+ - The `$use_sandpaper()` method for Episode objects will now remove "root" and
+   "layout" yaml directives (@zkamvar, #68)
+
 # pegboard 0.0.0.9031
 
 ## BUG FIX

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -224,6 +224,13 @@ Episode <- R6::R6Class("Episode",
         }
       }
       self$body <- use_sandpaper(self$body, rmd, yml)
+
+      # Remove the common yaml offenders
+      suppressWarnings(this_yaml <- self$get_yaml())
+      this_yaml[["root"]] <- NULL
+      this_yaml[["layout"]] <- NULL
+      self$yaml <- c("---", strsplit(yaml::as.yaml(this_yaml), "\n")[[1]], "---")
+
       type <- if (rmd) 'use_sandpaper_rmd' else 'use_sandpaper_md'
       private$mutations[type] <- TRUE
       invisible(self)
@@ -493,7 +500,9 @@ Episode <- R6::R6Class("Episode",
     #' loop <- Episode$new(file.path(lesson_fragment(), "_episodes", "14-looping-data-sets.md"))
     #' loop$validate_headings()
     validate_headings = function(verbose = TRUE, warn = TRUE) {
-      out <- validate_headings(self$headings, self$get_yaml()$title, offset = length(self$yaml))
+      out <- validate_headings(self$headings, 
+        self$get_yaml()$title, 
+        offset = length(self$yaml))
       if (is.null(out)) {
         return(out)
       }

--- a/tests/testthat/examples/post-image-tag.md
+++ b/tests/testthat/examples/post-image-tag.md
@@ -1,3 +1,9 @@
+---
+title: "testing post image tag"
+root: .
+layout: page
+---
+
 To create a new file from GitHub interface,
 click the `Add file` button and select `Create new file` from the dropdown.
 

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -34,7 +34,9 @@ test_that("Episodes can be created and are valid", {
 
 
 test_that("Episodes with image tags do not error", {
-  ep <- Episode$new(test_path("examples", "post-image-tag.md"))
+  suppressWarnings({
+    ep <- Episode$new(test_path("examples", "post-image-tag.md"))
+  })
   expect_length(ep$get_blocks(level = 0) , 2L)
   expect_length(ep$tags, 3L)
   tab <- make_link_table(ep$unblock()$use_sandpaper())


### PR DESCRIPTION
this will fix #68 by removing "root" and "layout" yaml items when converting to sandpaper
