### PR TITLE
update link validation to include separate files

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.2.1
+Version: 0.2.2
 Authors@R:c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,16 @@
+# pegboard 0.2.2
+
+ - If `getOption("sandpaper.links")` is not NULL (in the context of a {sandpaper}
+   lesson) and is a valid file, it will be appended to any file read in via 
+   `Episode$new()`
+ - `$validate_links()` no longer throws warnings about short or uninformative
+   text for link anchors (@zkamvar, #81)
+
+# pegboard 0.2.1
+
+ - External links files are now appended if the `sandpaper.links` option is set
+   to a valid file. 
+
 # pegboard 0.2.1
 
 ## MISC

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -33,6 +33,15 @@ Episode <- R6::R6Class("Episode",
       if (!file.exists(path)) {
         stop(glue::glue("the file '{path}' does not exist"))
       }
+      links <- getOption("sandpaper.links")
+      if (length(links) && fs::file_exists(links)) {
+        # if we have links, we concatenate our input files 
+        tmpin <- tempfile(fileext = ".md")
+        fs::file_copy(path, tmpin)
+        file.append(tmpin, links)
+        path <- tmpin
+        on.exit(unlink(tmpin), add = TRUE)
+      }
       default <- list(
         yaml = NULL,
         body = xml2::xml_missing()

--- a/R/utils-validation.R
+++ b/R/utils-validation.R
@@ -50,6 +50,7 @@ throw_link_warnings <- function(VAL) {
   if (length(VAL) == 0 || nrow(VAL) == 0) {
     return(invisible(NULL))
   }
+  VAL <- VAL[!VAL$anchor, , drop = FALSE]
   has_cli <- is.null(getOption("pegboard.no-cli")) &&
     requireNamespace("cli", quietly = TRUE)
   VAL <- collect_labels(VAL, cli = FALSE, link_tests)

--- a/R/validate_links.R
+++ b/R/validate_links.R
@@ -123,7 +123,7 @@ link_img_alt_text <- function(VAL) {
 
 #' @rdname validate_links
 link_length <- function(VAL) {
-  is_link <- VAL$type == "link"
+  is_link <- VAL$type == "link" & !VAL$anchor
   VAL$link_length[is_link] <- !grepl("^.?$", trimws(VAL$text[is_link]))
   VAL
 }
@@ -143,7 +143,8 @@ link_descriptive <- function(VAL) {
     ")[[:punct:]]*)$"
   )
   bad <- grepl(uninformative, trimws(VAL$text), ignore.case = TRUE, perl = TRUE)
-  VAL$descriptive <- !bad
+  body_links <- !VAL$anchor
+  VAL$descriptive[body_links] <- !bad[body_links]
   VAL
 }
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -93,7 +93,7 @@
     Code
       link$validate_links()
     Message <simpleMessage>
-      ! There were errors in 27/41 links
+      ! There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing
@@ -275,7 +275,7 @@
     Code
       link$validate_links()
     Message <cliMessage>
-      ! There were errors in 27/41 links
+      ! There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing
@@ -329,7 +329,7 @@
     Code
       link$validate_links()
     Message <cliMessage>
-      [33m![39m There were errors in 27/41 links
+      [33m![39m There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing
@@ -383,7 +383,7 @@
     Code
       link$validate_links()
     Message <cliMessage>
-      ! There were errors in 27/41 links
+      ! There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing
@@ -437,7 +437,7 @@
     Code
       link$validate_links()
     Message <cliMessage>
-      [33m![39m There were errors in 27/41 links
+      [33m![39m There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing
@@ -584,7 +584,7 @@
     Code
       link$validate_links()
     Message <cliMessage>
-      ! There were errors in 27/41 links
+      ! There were errors in 27/39 links
       
       - Links must use HTTPS <https://https.cio.gov/everything/>
       - Some link anchors for relative links (e.g. [anchor]: link) are missing

--- a/tests/testthat/examples/link-test.md
+++ b/tests/testthat/examples/link-test.md
@@ -70,9 +70,11 @@ If we have links like
 [read on about][bad-link-text],
 [a][bad-link-text],
 [][bad-link-text]
-they will fail.
+they will fail, but [link text that is descriptive][1], albiet with a numeric
+anchor will work.
 
 
+[1]: https://example.com/link-text#descriptive
 [rel-label-1]: #label-1
 [rel-image]: image-test.html
 [bad-link-text]: https://example.com/link-text#bad

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -32,6 +32,20 @@ test_that("Episodes can be created and are valid", {
 })
 
 
+test_that("Episodes from sandpaper will have links included", {
+
+  tnk <- withr::local_tempfile()
+  tep <- withr::local_tempfile()
+  writeLines("What [is this][link]?\n", tep)
+  writeLines("<!--comment-->\n\n[link]: https://example.com/link", tnk)
+  e <- Episode$new(tep, fix_links = FALSE)
+  expect_length(e$links, 0L)
+  withr::local_options(list(sandpaper.links = tnk))
+  e <- Episode$new(tep, fix_links = FALSE)
+  expect_length(e$links, 2L) # anchor and normal
+
+})
+
 
 test_that("Episodes with image tags do not error", {
   suppressWarnings({


### PR DESCRIPTION
This will add external link documents (in the context of sandpaper lessons) to the data.
It will also avoid reporting duplicate/spurious errors for anchor links to fix #81
