### PR TITLE
jekyll captions with URLs are captions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.2.6
+Version: 0.2.7
 Authors@R:c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# pegboard 0.2.7
+
+## MISC
+
+ - `make_pandoc_alt()` (an internal converter function) will no longer create alt
+   text from a caption if it contains a URL. This messes with the downstream
+   validation of image links.
+
 # pegboard 0.2.6
 
 ## BUG FIX

--- a/tests/testthat/test-make_pandoc_alt.R
+++ b/tests/testthat/test-make_pandoc_alt.R
@@ -3,11 +3,11 @@ test_that("make_pandoc_alt() converts alt text good", {
 
   txt <- paste(c("![has alt text](img1.png)", 
       "",
-   "![](needs-alt.png)", 
-      "",
-   "![ ](decorative.png)",
-      "",
-   "![has alt text](img2.png){: .class}", ""), collapse = "\n")
+   "![](needs-alt.png)", "",
+   "![ ](decorative.png)", "",
+   "![has alt text](img2.png){: .class}", "",
+   "![Is actually a caption https://example.com](actually-caption.png)", "",
+   NULL), collapse = "\n")
   f <- textConnection(txt)
   body <- tinkr::to_xml(f)$body
   ns <- tinkr::md_ns()
@@ -15,10 +15,10 @@ test_that("make_pandoc_alt() converts alt text good", {
   make_pandoc_alt(images)
   # Alt text is expected only when nodes indicate that it is expected
   expect_equal(xml2::xml_attr(images, "alt"), 
-    c("has alt text", NA, "", "has alt text"))
+    c("has alt text", NA, "", "has alt text", NA))
   # captions are not present (because we did not previously have ways to 
   # incorporate captions
   expect_equal(xml2::xml_text(images),
-    rep("", 4))
+    c(rep("", 4), "Is actually a caption https://example.com"))
 })
 


### PR DESCRIPTION
During the transition from kramdown to pandoc markdown, If the caption contains a URL, then it should not be converted to an alt
