### PR TITLE
minor update for new tinkr

### DIFF
--- a/.notes/namespaces.Rmd
+++ b/.notes/namespaces.Rmd
@@ -136,14 +136,14 @@ x <- read_xml(lst)
 ```
 
 The document has a namespace that points to "http://commonmark.org/xml/1.0" and
-that's used in the [stylesheet for {tinkr}](https://github.com/ropenscilabs/tinkr/blob/4980e816d876a86bb1ea07fe2b564701bc4bce22/inst/extdata/xml2md_gfm.xsl#L4-L5).
+that's used in the [stylesheet for {tinkr}](https://github.com/ropenscilabs/tinkr/blob/4980e816d876a86bb1ea07fe2b564701bc4bce22/inst/stylesheets/xml2md_gfm.xsl#L4-L5).
 
 If an item is in the commonmark namespace, it will be processed by the
 stylesheet. Tinkr does this via the {xslt} package, which provides an interface to the tempaltes and outputs text:
 
 ```{r xslt}
 library(xslt)
-stylesheet <- read_xml(system.file("extdata", "xml2md_gfm.xsl", package = "tinkr"))
+stylesheet <- read_xml(tinkr::stylesheet())
 cat(xslt::xml_xslt(x, stylesheet))
 xlist <- xml_find_first(x, ".//d1:list")
 xlist
@@ -230,7 +230,7 @@ break away from the {tinkr} package and focus on {commonmark} and {xslt}:
 
 
 ```{r}
-stylesheet <- read_xml(system.file("extdata", "xml2md_gfm.xsl", package = "tinkr"))
+stylesheet <- read_xml(tinkr::stylesheet())
 message(md <- "# hello\n\n`code` text\n\n```{r}\ncat('a code block')\n```")
 message(xmd <- commonmark::markdown_xml(md))
 x <- xml2::read_xml(xmd)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Description: The Carpentries (<https://carpentries.org>) curricula is made of of
 License: MIT + file LICENSE
 Imports:
     fs (>= 1.5.0),
-    tinkr (>= 0.0.0.9000),
+    tinkr (>= 0.0.0.9002),
     xml2,
     purrr,
     glue,
@@ -54,7 +54,7 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.0
+RoxygenNote: 7.2.1
 URL: https://carpentries.github.io/pegboard
 BugReports: https://github.com/carpentries/pegboard/issues
 VignetteBuilder: knitr

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.3.0
+Version: 0.3.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,13 @@
 # pegboard 0.3.0
 
+## MISC
+
+In preparation for {tinkr} 0.1.0, which changes the path of the default
+stylesheet, we are using the `tinkr::stylesheet()` convenience function to
+access it. 
+
+# pegboard 0.3.0
+
 ## NEW FEATURES
 
 ### Episode class objects

--- a/R/get_stylesheet.R
+++ b/R/get_stylesheet.R
@@ -1,4 +1,4 @@
-get_stylesheet <- function(sheet = "xml2md_gfm_kramdown.xsl", import = system.file("extdata", "xml2md_gfm.xsl", package = "tinkr")) {
+get_stylesheet <- function(sheet = "xml2md_gfm_kramdown.xsl", import = tinkr::stylesheet()) {
   tink <- xml2::url_escape(fs::path_real(import), reserved = c("/:\\"))
   ours <- system.file("stylesheets", sheet, package = "pegboard")
   styl <- readLines(ours)

--- a/man/Episode.Rd
+++ b/man/Episode.Rd
@@ -222,8 +222,8 @@ loop$validate_links()
 \if{html}{\out{
 <details open><summary>Inherited methods</summary>
 <ul>
-<li><span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="add_md"><a href='../../tinkr/html/yarn.html#method-yarn-add_md'><code>tinkr::yarn$add_md()</code></a></li>
-<li><span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="protect_math"><a href='../../tinkr/html/yarn.html#method-yarn-protect_math'><code>tinkr::yarn$protect_math()</code></a></li>
+<li><span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="add_md"><a href='../../tinkr/html/yarn.html#method-yarn-add_md'><code>tinkr::yarn$add_md()</code></a></span></li>
+<li><span class="pkg-link" data-pkg="tinkr" data-topic="yarn" data-id="protect_math"><a href='../../tinkr/html/yarn.html#method-yarn-protect_math'><code>tinkr::yarn$protect_math()</code></a></span></li>
 </ul>
 </details>
 }}

--- a/tests/testthat/test-get_stylesheet.R
+++ b/tests/testthat/test-get_stylesheet.R
@@ -2,7 +2,7 @@ test_that("stylesheet is properly escaped", {
 
   # copy the tinkr stylesheeet to a temporary file with a space
   tmp <- withr::local_tempfile(pattern = "file with space", fileext = ".xsl")
-  tnk <- system.file("extdata", "xml2md_gfm.xsl", package = "tinkr")
+  tnk <- tinkr::stylesheet()
   file.copy(tnk, tmp)
   file.copy(file.path(dirname(tnk), "xml2md.xsl"), file.path(dirname(tmp)))
   expect_identical(readLines(tmp), readLines(tnk))


### PR DESCRIPTION
This updates to use `tinkr::stylesheet()` for accessing the default stylesheet in tinkr. 
