### PR TITLE
Enable handouts without using knitr::purl()

### DIFF
--- a/R/Episode.R
+++ b/R/Episode.R
@@ -416,8 +416,13 @@ Episode <- R6::R6Class("Episode",
       code <- cp$code
       code <- code[xml2::xml_attr(code, "purl") %in% "TRUE"]
       isolate_elements(cp$body, challenges, code)
+      # set the comment character, default to hash, but could be set by 
+      # the option pegboard.handout.comment
+      comment_char <- getOption("pegboard.handout.comment") %||% "#"
+      xml2::xml_set_attr(cp$body, "comment", comment_char)
       cp$yaml <- c()
-      res <- tinkr::to_md(cp, path = path, stylesheet_path = get_stylesheet())
+      stysh <- get_stylesheet("xml2md_pegboard.xsl")
+      res <- tinkr::to_md(cp, path = path, stylesheet_path = stysh)
       if (is.null(path)) {
         invisible(res)
       } else {

--- a/R/fix_links.R
+++ b/R/fix_links.R
@@ -32,22 +32,6 @@ LINKS <- list(
   md_link   = gsb("(<ctext('[')>  and <ctext('][')>   and <ctext(']')>)")
 )
 
-#' Get the source for the link node fragments
-#'
-#' @param node a node determined to be a text representation of a link
-#'   destination
-#' @return the preceding three nodes, which will be by definition, the text
-#'   of the link.
-get_link_fragment_nodes <- function(node) {
-  the_parent <- xml2::xml_parent(node)
-  # note: we could replace this by using identical(parent$child, node)
-  txt <- xml2::xml_text(node)
-  xpath <- glue::glue("count(./md:text[text() = '{txt}']/preceding-sibling::*)")
-  num <- xml2::xml_find_num(the_parent, xpath, ns = tinkr::md_ns()) + 1L
-  xml2::xml_children(the_parent)[(num - 3L):num]
-}
-
-
 #' @description
 #' `fix_link_type()`: Fixes all links in the document based on the type of link
 #'

--- a/R/fix_links.R
+++ b/R/fix_links.R
@@ -32,6 +32,22 @@ LINKS <- list(
   md_link   = gsb("(<ctext('[')>  and <ctext('][')>   and <ctext(']')>)")
 )
 
+#' Get the source for the link node fragments
+#'
+#' @param node a node determined to be a text representation of a link
+#'   destination
+#' @return the preceding three nodes, which will be by definition, the text
+#'   of the link.
+get_link_fragment_nodes <- function(node) {
+  the_parent <- xml2::xml_parent(node)
+  # note: we could replace this by using identical(parent$child, node)
+  txt <- xml2::xml_text(node)
+  xpath <- glue::glue("count(./md:text[text() = '{txt}']/preceding-sibling::*)")
+  num <- xml2::xml_find_num(the_parent, xpath, ns = tinkr::md_ns()) + 1L
+  xml2::xml_children(the_parent)[(num - 3L):num]
+}
+
+
 #' @description
 #' `fix_link_type()`: Fixes all links in the document based on the type of link
 #'

--- a/R/get_stylesheet.R
+++ b/R/get_stylesheet.R
@@ -1,4 +1,4 @@
-get_stylesheet <- function(sheet = "xml2md_gfm_kramdown.xsl", import = tinkr::stylesheet()) {
+get_stylesheet <- function(sheet = "xml2md_gfm_kramdown.xsl", import = tinkr::stylesheet(), params = list()) {
   tink <- xml2::url_escape(fs::path_real(import), reserved = c("/:\\"))
   ours <- system.file("stylesheets", sheet, package = "pegboard")
   styl <- readLines(ours)

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,6 +25,8 @@ element_df <- function(node) {
 
 # nocov end
 
+`%||%` <- function(a, b) if (is.null(a)) b else a
+
 has_cli <- function() {
   is.null(getOption("pegboard.no-cli")) && requireNamespace("cli", quietly = TRUE)
 }

--- a/R/xml_to_md.R
+++ b/R/xml_to_md.R
@@ -10,7 +10,7 @@
 #' xml2::xml_add_child(cha, xml2::xml_child(sol, 1), .where =  1)
 #' xml2::xml_add_child(cha, xml2::xml_child(sol, 2), .where = 2)
 #' cat(pegboard:::xml_to_md(cha))
-xml_to_md <- function(body, stylesheet = "xml2md_roxy.xsl") {
+xml_to_md <- function(body, stylesheet = "xml2md_pegboard.xsl") {
   stysh <- xml2::read_xml(get_stylesheet(stylesheet))
   is_fragment <- xml2::xml_name(body) != "document" ||
     xml2::xml_name(xml2::xml_parent(body)) != ""

--- a/inst/sandpaper-fragment/episodes/intro.Rmd
+++ b/inst/sandpaper-fragment/episodes/intro.Rmd
@@ -39,6 +39,7 @@ Carpentries lesson template:
 ## Challenge 1: Can you do it?
 
 What is the output of this command?
+Hint: it will be length 1.
 
 ```{r, eval = FALSE}
 paste("This", "new", "template", "looks", "good")

--- a/inst/stylesheets/xml2md_pegboard.xsl
+++ b/inst/stylesheets/xml2md_pegboard.xsl
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+    version="1.0"
+    xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+    xmlns:md="http://commonmark.org/xml/1.0">
+
+
+<!-- 
+  
+  Convert Markdown Document to a commented/annotated code handout
+  ===============================================================
+
+  This stylesheet assumes that you have preprocessed all direct children of the
+  document with `@comment` attributes, specifying the comment character:
+
+      xml2::xml_children(doc) |> xml2::xml_set_attr("comment", "#")
+
+  When we do this, the stylesheet knows to insert a comment character before
+  processing the content. 
+
+  This stylesheet was previously used to collapse callout blocks into code
+  blocks with roxygen2 comments. I have repurposed it to process handouts
+
+--> 
+
+<!-- Import tinkr XSL -->
+<!-- NOTE: the FIXME is replaced dynamically in R by the path to tinkr's stylesheet -->
+<xsl:import href="FIXME"/>
+<xsl:variable name="comment" select="md:document/@comment" />
+
+<!-- This part handles the top-level elements starting an indent block (headers/lists) -->
+<xsl:template match="/md:document[@comment]/md:*" mode="indent-block">
+    <xsl:value-of select="$comment" />
+    <xsl:text> </xsl:text>
+    <xsl:apply-imports select="md:*" mode="indent-block"/>
+    <!-- This prevents an extra comment from appearing at the top of the doc -->
+    <xsl:if test="preceding-sibling::md:*">
+        <xsl:value-of select="$comment" />
+        <xsl:text> </xsl:text>
+    </xsl:if>
+</xsl:template>
+
+<!--
+This part prefixes all of the internal elements of blocks
+(any newlines as part of the paragraph or secondary list elements)
+-->
+<xsl:template match="/md:document[@comment]/md:*" mode="indent">
+    <xsl:value-of select="$comment" />
+    <xsl:text> </xsl:text>
+</xsl:template>
+
+<!--
+  This is a modified copy of the code block directive from the xml2md stylesheet
+  in {tinkr}. It adds a single comment character before the final code fence.
+-->
+<xsl:template match="/md:document[@comment]//md:code_block">
+    <xsl:apply-templates select="." mode="indent-block"/>
+
+    <xsl:variable name="t" select="string(.)"/>
+    <xsl:variable name="delim">
+        <xsl:call-template name="code-delim">
+            <xsl:with-param name="text" select="$t"/>
+            <xsl:with-param name="delim" select="'```'"/>
+        </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:value-of select="$delim"/>
+    <xsl:value-of select="@info"/>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:call-template name="indent-lines">
+        <xsl:with-param name="code" select="$t"/>
+    </xsl:call-template>
+    <xsl:apply-templates select="ancestor::md:*" mode="indent"/>
+    <!-- ZNK: add single comment character before final fence -->
+    <xsl:value-of select="$comment" />
+    <xsl:text> </xsl:text>
+    <xsl:value-of select="$delim"/>
+    <xsl:text>&#10;</xsl:text>
+</xsl:template>
+
+<!--
+  DEPRECATED
+
+  When there is a "xygen" tag, this adds the tag before the text like so:
+  <comment>
+  <comment> @<xygen>
+  ...stuff here ...
+-->
+<xsl:template match="md:*[@xygen]">
+    <xsl:value-of select="@comment"/>
+    <xsl:text>&#10;</xsl:text>
+    <xsl:value-of select="@comment"/>
+    <xsl:text> &#64;</xsl:text>
+    <xsl:value-of select="@xygen"/>
+    <xsl:choose>
+    <!-- If the current node is a heading node, then it's part of the tag -->
+        <xsl:when test="boolean(self::md:heading[@level='2'])">
+            <xsl:text> </xsl:text>
+            <xsl:value-of select='self::md:heading[1]'/>
+            <xsl:text>&#10;</xsl:text>
+        </xsl:when>
+    <!-- In all other cases, the node is processed normally -->
+        <xsl:otherwise>
+            <xsl:text>&#10;</xsl:text>
+            <xsl:apply-imports select="md:*" mode="indent"/>
+            <xsl:value-of select="@comment"/>
+        </xsl:otherwise>
+    </xsl:choose>
+</xsl:template>
+
+<xsl:output method="text" encoding="utf-8"/>
+
+</xsl:stylesheet>

--- a/tests/testthat/_snaps/Episode.md
+++ b/tests/testthat/_snaps/Episode.md
@@ -3,110 +3,78 @@
     Code
       cat(e$handout())
     Output
-      ```{r retained, purl=TRUE}
+      # ```{r retained, purl=TRUE}
       echo("this code is retained")
-      ```
-      
-      ### A challenge
-      
-      Text text
-      
-      1. task
-      2. task
-      
-      ```{r challenge}
+      # ```
+      # 
+      # ### A challenge
+      # 
+      # Text text
+      # 
+      # 1. task
+      # 2. task
+      # 
+      # ```{r challenge}
       v <- rnorm(10)
       the_sum <- 0
       for (i in v) {
         the_sum <- the_sum + i
       }
       the_mean <- the_sum / length(v)
-      ```
-      
-      How do you simplify this?
-      
-      ### Smol challenge
-      
-      A small challenge here with just text
+      # ```
+      # 
+      # How do you simplify this?
+      # 
+      # ### Smol challenge
+      # 
+      # A small challenge here with just text
 
 ---
 
     Code
       cat(e$handout(solution = TRUE))
     Output
-      ```{r retained, purl=TRUE}
+      # ```{r retained, purl=TRUE}
       echo("this code is retained")
-      ```
-      
-      ### A challenge
-      
-      Text text
-      
-      1. task
-      2. task
-      
-      ```{r challenge}
+      # ```
+      # 
+      # ### A challenge
+      # 
+      # Text text
+      # 
+      # 1. task
+      # 2. task
+      # 
+      # ```{r challenge}
       v <- rnorm(10)
       the_sum <- 0
       for (i in v) {
         the_sum <- the_sum + i
       }
       the_mean <- the_sum / length(v)
-      ```
-      
-      How do you simplify this?
-      
-      :::: solution
-      
-      You can use the `mean()` function
-      
-      ```{r}
+      # ```
+      # 
+      # How do you simplify this?
+      # 
+      # :::: solution
+      # 
+      # You can use the `mean()` function
+      # 
+      # ```{r}
       mean(rnorm(10))
-      ```
-      
-      ::::
-      
-      ### Smol challenge
-      
-      A small challenge here with just text
-      
-      :::: solution
-      
-      ```{r}
+      # ```
+      # 
+      # ::::
+      # 
+      # ### Smol challenge
+      # 
+      # A small challenge here with just text
+      # 
+      # :::: solution
+      # 
+      # ```{r}
       cat("this is the solution")
-      ```
-      
-      ::::
-
----
-
-    Code
-      cat(tinkr::yarn$new(rmd)$show(), sep = "\n")
-    Output
-      ```{r retained, purl=TRUE}
-      echo("this code is retained")
-      ```
-      
-      ### A challenge
-      
-      Text text
-      
-      1. task
-      2. task
-      
-      ```{r challenge}
-      v <- rnorm(10)
-      the_sum <- 0
-      for (i in v) {
-        the_sum <- the_sum + i
-      }
-      the_mean <- the_sum / length(v)
-      ```
-      
-      How do you simplify this?
-      
-      ### Smol challenge
-      
-      A small challenge here with just text
-      
+      # ```
+      # 
+      # ::::
 

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -129,28 +129,21 @@ test_that("handouts can be created", {
   expect_snapshot(cat(e$handout(solution = TRUE)))
   rmd <- fs::file_temp(ext = "Rmd")
   out <- fs::file_temp(ext = "R")
-  withr::local_file(c(rmd, out))
+  withr::local_file(c(out))
   
   # handout with a file returns the original Episode object
-  expect_false(fs::file_exists(rmd))
+  expect_false(fs::file_exists(out))
   # The object is still not affected by the handout
-  expect_length(e$handout(rmd)$solutions, 2)
-  expect_true(fs::file_exists(rmd))
-  expect_snapshot(cat(tinkr::yarn$new(rmd)$show(), sep = "\n"))
-
-  if (requireNamespace("knitr", quietly = TRUE)) {
-    expect_false(fs::file_exists(out))
-    knitr::purl(rmd, out, documentation = 2, quiet = TRUE)
-    expected <- c("echo(\"this code is retained\")",
-      "v <- rnorm(10)", 
-      "the_sum <- 0", 
-      "for (i in v) {\n    the_sum <- the_sum + i\n}", 
-      "the_mean <- the_sum/length(v)"
-    )
-    expect_true(fs::file_exists(out))
-    expect_equal(as.character(parse(out)), expected)
-  }
-
+  expect_length(e$handout(out)$solutions, 2)
+  # The output file can be parsed into valid R code
+  expected <- c("echo(\"this code is retained\")",
+    "v <- rnorm(10)", 
+    "the_sum <- 0", 
+    "for (i in v) {\n    the_sum <- the_sum + i\n}", 
+    "the_mean <- the_sum/length(v)"
+  )
+  expect_true(fs::file_exists(out))
+  expect_equal(as.character(parse(out)), expected)
 })
 
 


### PR DESCRIPTION
This adds a handout stylesheet that is used to generate code handout documents which can be used for instruction.

The trick is that we add a `comment` attribute to the document node and then add special xsl rules to handle downstream nodes. 