### PR TITLE
Fix alt text validation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,19 @@
+# pegboard 0.4.3
+
+BUG FIX
+-------
+
+* A bug where attributes following an image would cause missing alt text to not
+  be reported was fixed. (discovered: @dpshelio and @karenword; 
+  reported: @zkamvar #106; fixed: @zkamvar #108). This fix also makes the alt
+  text parsing and validation more robust
+
+INTERNALS
+---------
+
+* New internal function `find_between_nodes()` will get all nodes between two
+  sibling nodes.
+
 # pegboard 0.4.2
 
 ## TESTS

--- a/R/get_images.R
+++ b/R/get_images.R
@@ -32,7 +32,7 @@ get_images <- function(yrn, process = TRUE) {
 #' @return a copy of the nodelist
 #' @keywords internal
 process_images <- function(images, ns = tinkr::md_ns()) {
-  xpath <- "self::*/following-sibling::md:text[starts-with(text(), '{')]"
+  xpath <- "self::*/following-sibling::*[1]/self::*[starts-with(text(), '{')]"
   have_alts <- xml2::xml_find_lgl(images, glue::glue("boolean({xpath})"), ns)
   have_no_attr <- is.na(xml2::xml_attr(images[have_alts], "alt"))
   html_nodes <- grepl("html_", xml2::xml_name(images))

--- a/R/get_images.R
+++ b/R/get_images.R
@@ -92,7 +92,10 @@ set_alt_attr <- function(images, xpath, ns) {
   htmls <- paste(gsub("[{](.+?)[}]", "<img \\1/>", attr_texts), collapse = "\n")
   htmls <- xml2::read_html(htmls)
   alts <- xml2::xml_find_all(htmls, ".//img")
-  xml2::xml_set_attr(images, "alt", xml2::xml_attr(alts, "alt"))
+  alts <- xml2::xml_attr(alts, "alt")
+  purrr::walk2(images, alts, function(img, alt) {
+    if (!is.na(alt)) xml2::xml_set_attr(img, "alt", alt)
+  })
   invisible(images)
 }
 

--- a/R/get_images.R
+++ b/R/get_images.R
@@ -87,7 +87,7 @@ set_alt_attr <- function(images, xpath, ns) {
     fixed_text <- purrr::map_chr(attrs[no_closing], get_broken_attr_text, ns)
     attr_texts[no_closing] <- fixed_text
   }
-  htmls <- paste(gsub("[{](.+?)[}]", "<img \\1/>", attr_texts), collapse = "\n")
+  htmls <- paste(gsub("[{](.+)[}]", "<img \\1/>", attr_texts), collapse = "\n")
   htmls <- xml2::read_html(htmls)
   alts <- xml2::xml_find_all(htmls, ".//img")
   alts <- xml2::xml_attr(alts, "alt")

--- a/R/utils.R
+++ b/R/utils.R
@@ -23,6 +23,27 @@ element_df <- function(node) {
   )
 }
 
+#' @param node a node determined to be a text representation of a link
+#'   destination
+#' @return 
+#'  - `get_link_fragments()`: the preceding three or four nodes, which will be
+#'  the text of the link or the alt text of the image.
+#' @rdname fix_links
+find_between_nodes <- function(a, b, include = TRUE) {
+  the_parent <- xml2::xml_parent(a)
+  if (!identical(the_parent, xml2::xml_parent(b))) {
+    # we cannot return a space between nodes on different levels
+    return(xml2::xml_missing())
+  }
+  the_children <- xml2::xml_children(the_parent)
+  # find the node in question by testing for identity since they represent the
+  # same object, they will be identical. 
+  ida <- which(purrr::map_lgl(the_children, identical, a))
+  idb <- which(purrr::map_lgl(the_children, identical, b))
+  # test for image with endsWith because they may have an inline image.
+  the_children[seq(ida, idb)]
+}
+
 # nocov end
 
 has_cli <- function() {

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -5,11 +5,14 @@ test_that("markdown images will process alt text appropriately", {
     "![image2](b.png){alt='text\nalt' width='20%'}", 
     "![image3](c.png){ width='31%' alt='something long and proseful' style='border-radius: \"50%\"'}", 
     "![",
-    "image3 with a longer caption", 
-    "](c.png){ width='31%'",
+    "image4 with a longer caption", 
+    "](d.png){ width='31%'",
     "alt='attributes on separate lines'",
-    "style='border-radius: \"25%\"}'",
-    "![image4](d.png)", 
+    "style='border-radius: \"25%\"'}",
+    "![image5](e.png)", 
+    "![The {pegboard} package](pegboard.png){width='49%'",
+    "alt='The logo for the {pegboard} package, which",
+    "appears as a little workshop with a pegboard on the wall'}",
     "text")
   txt <- paste(imgs, collapse = "\n")
   
@@ -21,7 +24,8 @@ test_that("markdown images will process alt text appropriately", {
     "text alt", 
     "something long and proseful", 
     "attributes on separate lines",
-    NA_character_)
+    NA_character_,
+  "The logo for the {pegboard} package, which appears as a little workshop with a pegboard on the wall")
   expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
 })
 

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -1,12 +1,21 @@
 
 test_that("markdown images will process alt text appropriately", {
-  txt <- "![image1](a.png){width='20%'}\n![image2](b.png){alt='text\nalt' width='40%'}\n![image3](c.png)\ntext"
+  imgs <- c(
+    "![image1](a.png){width='20%'}", 
+    "![image2](b.png){alt='text\nalt' width='20%'}", 
+    "![image2](b.png){ width='30%' alt='something long and proseful' style='border-radius: \"50%\"'}", 
+    "![image3](c.png)", 
+    "text")
+  txt <- paste(imgs, collapse = "\n")
   
   xml <- xml2::read_xml(commonmark::markdown_xml(txt))
   ns  <- tinkr::md_ns()
   images <- xml2::xml_find_all(xml, ".//md:image", ns = ns)
   process_images(images, ns)
-  expected_alts <- c(NA_character_, "text alt", NA_character_)
+  expected_alts <- c(NA_character_, 
+    "text alt", 
+    "something long and proseful", 
+    NA_character_)
   expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
 })
 

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -3,8 +3,13 @@ test_that("markdown images will process alt text appropriately", {
   imgs <- c(
     "![image1](a.png){width='20%'}", 
     "![image2](b.png){alt='text\nalt' width='20%'}", 
-    "![image2](b.png){ width='30%' alt='something long and proseful' style='border-radius: \"50%\"'}", 
-    "![image3](c.png)", 
+    "![image3](c.png){ width='31%' alt='something long and proseful' style='border-radius: \"50%\"'}", 
+    "![",
+    "image3 with a longer caption", 
+    "](c.png){ width='31%'",
+    "alt='attributes on separate lines'",
+    "style='border-radius: \"25%\"}'",
+    "![image4](d.png)", 
     "text")
   txt <- paste(imgs, collapse = "\n")
   
@@ -15,6 +20,7 @@ test_that("markdown images will process alt text appropriately", {
   expected_alts <- c(NA_character_, 
     "text alt", 
     "something long and proseful", 
+    "attributes on separate lines",
     NA_character_)
   expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
 })

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -1,0 +1,13 @@
+
+test_that("markdown images will process alt text appropriately", {
+  txt <- "![image1](a.png){width='20%'}\n![image2](b.png){alt='text alt' width='40%'}\n![image3](c.png)\ntext"
+  
+  xml <- xml2::read_xml(commonmark::markdown_xml(txt))
+  ns  <- tinkr::md_ns()
+  xpath <- "self::*/following-sibling::md:text[starts-with(text(), '{')]"
+  images <- xml2::xml_find_all(xml, ".//md:image", ns = ns)
+  set_alt_attr(images, xpath, ns)
+  expected_alts <- c(NA_character_, "text_alt", NA_character_)
+  expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
+})
+

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -1,13 +1,12 @@
 
 test_that("markdown images will process alt text appropriately", {
-  txt <- "![image1](a.png){width='20%'}\n![image2](b.png){alt='text alt' width='40%'}\n![image3](c.png)\ntext"
+  txt <- "![image1](a.png){width='20%'}\n![image2](b.png){alt='text\nalt' width='40%'}\n![image3](c.png)\ntext"
   
   xml <- xml2::read_xml(commonmark::markdown_xml(txt))
   ns  <- tinkr::md_ns()
-  xpath <- "self::*/following-sibling::md:text[starts-with(text(), '{')]"
   images <- xml2::xml_find_all(xml, ".//md:image", ns = ns)
-  set_alt_attr(images, xpath, ns)
-  expected_alts <- c(NA_character_, "text_alt", NA_character_)
+  process_images(images, ns)
+  expected_alts <- c(NA_character_, "text alt", NA_character_)
   expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
 })
 


### PR DESCRIPTION
This will fix validation for alt text

This will fix #106. Now pegboard will process the following types of images


```markdown
![image1](a.png){width='20%'}

![image2](b.png){alt='text
alt' width='20%'}

![image3](c.png){ width='31%' alt='something long and proseful' style='border-radius: "50%"'}

![
image4 with a longer caption
](d.png){ width='31%'
alt='attributes on separate lines'
style='border-radius: "25%"'}

![image5](e.png)

![The {pegboard} package](pegboard.png){width='49%'
alt='The logo for the {pegboard} package, which
appears as a little workshop with a pegboard on the wall'}

text
```

Valiation shows that the images are processed appropriately (e.g. two images do not have alt text)

```r
> pegboard::Episode$new(tmp)$validate_links()
! There were errors in 6/6 links
◌ Some linked internal files do not exist
◌ Images need alt-text
<https://webaim.org/techniques/hypertext/link_text#alt_link>

file241e94bcf6174:1 [missing file] a.png [image missing alt-text]
file241e94bcf6174:3 [missing file] b.png
file241e94bcf6174:6 [missing file] c.png
file241e94bcf6174:10 [missing file] d.png
file241e94bcf6174:14 [missing file] e.png [image missing alt-text]
file241e94bcf6174:16 [missing file] pegboard.png
```

Processing the images also shows that the alt text is rendered as expected:

```r
> pegboard::Episode$new(tmp)$get_images(process = TRUE) |> xml2::xml_attr("alt")
[1] NA

[2] "text alt"

[3] "something long and proseful"

[4] "attributes on separate lines"

[5] NA

[6] "The logo for the {pegboard} package, which appears as a little workshop with a
 pegboard on the wall"
```