### PR TITLE
update validator to include non-episode content

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.4.3
+Version: 0.4.4
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",
@@ -23,7 +23,7 @@ Description: The Carpentries (<https://carpentries.org>) curricula is made of of
 License: MIT + file LICENSE
 Imports:
     fs (>= 1.5.0),
-    tinkr (>= 0.1.0.9000),
+    tinkr (>= 0.2.0),
     xml2,
     purrr,
     glue,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,15 @@
-# pegboard 0.4.3
+# pegboard 0.4.4 (unreleased)
+
+* `Lesson` object validators now validate non-episode files
+  (reported: @zkamvar #110; fixed: @zkamvar #113).
+
+DEPENDENCIES
+------------
+
+* `{tinkr}`'s minimum version has been set to 0.2.0 to recognise the release to
+  CRAN and bring in new bugfixes.
+
+# pegboard 0.4.3 (2023-01-26)
 
 NEW FEATURES
 ------------
@@ -23,7 +34,7 @@ INTERNALS
 * New internal function `find_between_nodes()` will get all nodes between two
   sibling nodes.
 
-# pegboard 0.4.2
+# pegboard 0.4.2 (2023-01-10)
 
 ## TESTS
 
@@ -34,13 +45,13 @@ INTERNALS
 
 * Internal `fix_links()` function has improved documentation.
 
-# pegboard 0.4.1
+# pegboard 0.4.1 (2023-01-06)
 
 ## TESTS
 
 * A test that dependend on an upstream resource was fixed.
 
-# pegboard 0.4.0
+# pegboard 0.4.0 (2023-01-06)
 
 ## DEPENDENCIES
 
@@ -57,7 +68,7 @@ INTERNALS
 * GitHub workflows have been updated to run weekly.
 
 
-# pegboard 0.3.2
+# pegboard 0.3.2 (2022-09-14)
 
 ## DEPENDENCIES
 
@@ -66,7 +77,7 @@ INTERNALS
  - Soft dependencies ggraph, ggplot2, and tidygraph have been removed. These
    dependencies were only needed for producing a now-out-of-date survey document
 
-# pegboard 0.3.1
+# pegboard 0.3.1 (2022-08-16)
 
 ## MISC
 
@@ -74,7 +85,7 @@ In preparation for {tinkr} 0.1.0, which changes the path of the default
 stylesheet, we are using the `tinkr::stylesheet()` convenience function to
 access it. 
 
-# pegboard 0.3.0
+# pegboard 0.3.0 (2022-05-25)
 
 ## NEW FEATURES
 
@@ -115,7 +126,7 @@ access it.
    validation of image links.
  - `fix_sandpaper_links()` now also fixes links that use `{{ site.baseurl }}`.
 
-# pegboard 0.2.6
+# pegboard 0.2.6 (2022-05-11)
 
 ## BUG FIX
 
@@ -124,7 +135,7 @@ access it.
     - internal function `find_lesson_links()` no longer expects links to be 
       strictly in paragraph elements.
 
-# pegboard 0.2.5
+# pegboard 0.2.5 (2022-05-10)
 
 ## MISC
 
@@ -133,20 +144,20 @@ access it.
    this is here just in case it's needed.
    Source: https://webaim.org/techniques/alttext/#decorative
 
-# pegboard 0.2.4
+# pegboard 0.2.4 (2022-02-25)
 
 ## DEPENDENCIES
 
  - The {fs} package needs to be >= 1.5.0 (#83, @sstevens2)
 
-# pegboard 0.2.3
+# pegboard 0.2.3 (2022-02-23)
 
 ## BUG FIX
 
  - footnotes with no trailing newline are no longer accidentally appended with
    relative link anchors when `getOption('sandpaper.links')` is not NULL.
 
-# pegboard 0.2.2
+# pegboard 0.2.2 (2022-02-23)
 
 ## NEW FEATURES
 
@@ -159,26 +170,26 @@ access it.
  - `$validate_links()` no longer throws warnings about short or uninformative
    text for link anchors (@zkamvar, #81)
 
-# pegboard 0.2.1
+# pegboard 0.2.1 (2022-02-18)
 
 ## MISC
 
  - The inline messages for link validation errors are more verbose (@tobyhodges, #79)
 
-# pegboard 0.2.0
+# pegboard 0.2.0 (2022-02-17)
 
 ## NEW FEATURES
 
  - `validate_divs()` will validate that the divs in an Episode are ones we
    expect.
 
-# pegboard 0.1.1
+# pegboard 0.1.1 (2022-02-02)
 
 ## MISC
 
  - Correct mis-attribution for LICENSE
 
-# pegboard 0.1.0
+# pegboard 0.1.0 (2022-02-01)
 
 This is a soft release of {pegboard} to coincide with the first announcement of
 The Carpentries Workbench.

--- a/R/Lesson.R
+++ b/R/Lesson.R
@@ -304,7 +304,7 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_headings()
     validate_headings = function(verbose = TRUE) {
-      res <- purrr::map(self$episodes, 
+      res <- purrr::map(c(self$episodes, self$extra), 
         ~.x$validate_headings(verbose = verbose, warn = FALSE)
       )
       res <- stack_rows(res)
@@ -330,7 +330,7 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_divs()
     validate_divs = function() {
-      res <- purrr::map(self$episodes, ~.x$validate_divs(warn = FALSE))
+      res <- purrr::map(c(self$episodes, self$extra), ~.x$validate_divs(warn = FALSE))
       res <- stack_rows(res)
       throw_div_warnings(res)
       invisible(res)
@@ -359,7 +359,7 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_links()
     validate_links = function() {
-      res <- purrr::map(self$episodes, ~.x$validate_links(warn = FALSE))
+      res <- purrr::map(c(self$episodes, self$extra), ~.x$validate_links(warn = FALSE))
       res <- stack_rows(res)
       throw_link_warnings(res)
       invisible(res)

--- a/inst/sandpaper-fragment/learners/setup.md
+++ b/inst/sandpaper-fragment/learners/setup.md
@@ -15,7 +15,7 @@ setup instructions, you can use a `solution` tag.
 
 ## For Windows
 
-Use PuTTY
+Use [the PuTTY terminal](http://example.com/putty)
 
 :::::::::::::::::::::::::
 
@@ -23,7 +23,7 @@ Use PuTTY
 
 ## For MacOS
 
-Use Terminal.app
+Use [Terminal.app](http://example.com/terminal)
 
 :::::::::::::::::::::::::
 

--- a/tests/testthat/_snaps/Lesson.md
+++ b/tests/testthat/_snaps/Lesson.md
@@ -1,3 +1,75 @@
+# Sandpaper Lessons can be validated [plain]
+
+    Code
+      vhead <- snd$validate_headings()
+
+---
+
+    Code
+      vlink <- snd$validate_links()
+    Message <cliMessage>
+      ! There were errors in 2/3 links
+      ( ) Links must use HTTPS <https://https.cio.gov/everything/>
+      
+      ::warning file=learners/setup.md,line=18:: [needs HTTPS]
+      http://example.com/putty
+      ::warning file=learners/setup.md,line=26:: [needs HTTPS]
+      http://example.com/terminal
+
+# Sandpaper Lessons can be validated [ansi]
+
+    Code
+      vhead <- snd$validate_headings()
+
+---
+
+    Code
+      vlink <- snd$validate_links()
+    Message <cliMessage>
+      [33m![39m There were errors in 2/3 links
+      ( ) Links must use HTTPS <https://https.cio.gov/everything/>
+      
+      ::warning file=learners/setup.md,line=18:: [needs HTTPS]
+      http://example.com/putty
+      ::warning file=learners/setup.md,line=26:: [needs HTTPS]
+      http://example.com/terminal
+
+# Sandpaper Lessons can be validated [unicode]
+
+    Code
+      vhead <- snd$validate_headings()
+
+---
+
+    Code
+      vlink <- snd$validate_links()
+    Message <cliMessage>
+      ! There were errors in 2/3 links
+      ◌ Links must use HTTPS <https://https.cio.gov/everything/>
+      
+      ::warning file=learners/setup.md,line=18:: [needs HTTPS]
+      http://example.com/putty
+      ::warning file=learners/setup.md,line=26:: [needs HTTPS]
+      http://example.com/terminal
+
+# Sandpaper Lessons can be validated [fancy]
+
+    Code
+      vhead <- snd$validate_headings()
+
+---
+
+    Code
+      vlink <- snd$validate_links()
+    Message <cliMessage>
+      [33m![39m There were errors in 2/3 links
+      ◌ Links must use HTTPS <https://https.cio.gov/everything/>
+      
+      ::warning file=learners/setup.md,line=18:: [needs HTTPS]
+      http://example.com/putty
+      ::warning file=learners/setup.md,line=26:: [needs HTTPS]
+      http://example.com/terminal
+
 # Sandpaper lessons have getter and summary methods
 
     Code
@@ -9,7 +81,7 @@
       1 intro.Rmd        6        6        6          1         2     3      0       0     0      0     1
       2 index.md         0        0        0          0         0     0      0       0     0      0     0
       3 a.md             0        0        0          0         0     0      0       0     0      0     0
-      4 setup.md         2        2        3          0         2     0      0       0     0      0     0
+      4 setup.md         2        2        3          0         2     0      0       0     0      0     2
       5 b.md             0        0        0          0         0     0      0       0     0      0     0
 
 ---
@@ -33,7 +105,7 @@
       1 intro.Rmd                  6        6        6          1         2     3      0       0     0      0     1
       2 index.md                   0        0        0          0         0     0      0       0     0      0     0
       3 a.md                       0        0        0          0         0     0      0       0     0      0     0
-      4 setup.md                   2        2        3          0         2     0      0       0     0      0     0
+      4 setup.md                   2        2        3          0         2     0      0       0     0      0     2
       5 b.md                       0        0        0          0         0     0      0       0     0      0     0
       6 site/built/intro.md        6        6        6          1         2     3      1       0     0      1     1
 

--- a/tests/testthat/test-Lesson.R
+++ b/tests/testthat/test-Lesson.R
@@ -24,6 +24,25 @@ test_that("Sandpaper lessons can be read", {
   expect_s3_class(snd$extra[[1]], "Episode")
 })
 
+if (requireNamespace("cli")) {
+  cli::test_that_cli("Sandpaper Lessons can be validated", {
+    snd <- Lesson$new(path = lesson_fragment("sandpaper-fragment"), jekyll = FALSE)
+    withr::local_envvar(list(CI = 'true'))
+    expect_snapshot(vhead <- snd$validate_headings())
+    expect_equal(nrow(vhead), 8L)
+    expect_snapshot(vlink <- snd$validate_links())
+    expect_equal(nrow(vlink), 3L)
+  })
+}
+
+test_that("Sandpaper Lessons can be _quietly_ validated", {
+  snd <- Lesson$new(path = lesson_fragment("sandpaper-fragment"), jekyll = FALSE)
+  suppressMessages({
+  expect_message(vhead <- snd$validate_headings(verbose = FALSE), NA)
+  expect_message(vlink <- snd$validate_links(), "There were errors in 2/3 links")
+  })
+})
+
 test_that("Sandpaper lessons have getter and summary methods", {
   snd <- Lesson$new(path = lesson_fragment("sandpaper-fragment"), jekyll = FALSE)
   # sandpaper lessons will have their divs pre-labeled.


### PR DESCRIPTION
This will now mean that running `$validate_links()` on a lesson object will provide validators for _all_ markdown files in the lesson, not just those under `episodes`

This will fix #110 