### PR TITLE
bypass README in checks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.5.1
+Version: 0.5.2
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# pegboard 0.5.2 (2023-04-05)
+
+BUG FIX
+-------
+
+* The README file is no longer run through validation as it is not generally a
+  part of the website and more often than not, creates distractions.
+
 # pegboard 0.5.1 (2023-03-31)
 
 BUG FIX

--- a/R/Lesson.R
+++ b/R/Lesson.R
@@ -305,7 +305,10 @@ Lesson <- R6::R6Class("Lesson",
     #' frg$validate_headings()
     validate_headings = function(verbose = TRUE) {
       res <- purrr::map(c(self$episodes, self$extra), 
-        ~.x$validate_headings(verbose = verbose, warn = FALSE)
+        function(x) {
+          if (startsWith(x$name, "README")) return(NULL)
+          x$validate_headings(verbose = verbose, warn = FALSE)
+        }
       )
       res <- stack_rows(res)
       throw_heading_warnings(res)
@@ -330,7 +333,12 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_divs()
     validate_divs = function() {
-      res <- purrr::map(c(self$episodes, self$extra), ~.x$validate_divs(warn = FALSE))
+      res <- purrr::map(c(self$episodes, self$extra), 
+        function(x) {
+          if (startsWith(x$name, "README")) return(NULL)
+          x$validate_divs(warn = FALSE)
+        }
+      )
       res <- stack_rows(res)
       throw_div_warnings(res)
       invisible(res)
@@ -359,7 +367,12 @@ Lesson <- R6::R6Class("Lesson",
     #' frg <- Lesson$new(lesson_fragment())
     #' frg$validate_links()
     validate_links = function() {
-      res <- purrr::map(c(self$episodes, self$extra), ~.x$validate_links(warn = FALSE))
+      res <- purrr::map(c(self$episodes, self$extra),
+        function(x) {
+          if (startsWith(x$name, "README")) return(NULL)
+          x$validate_links(warn = FALSE)
+        }
+      )
       res <- stack_rows(res)
       throw_link_warnings(res)
       invisible(res)


### PR DESCRIPTION
This avoids unnecessary noise