### PR TITLE
fix link parsing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.5.2
+Version: 0.5.3
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,14 @@
+# pegboard 0.5.3 (unreleased)
+
+BUG FIX
+-------
+
+* liquid-formatted links with markdown inside them are now more accurately
+  transitioned to use {sandpaper} (reported: @uschille, https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar, #121)
+- images with kramdown attributes that are on a new line are now more accurately
+  transitioned to use {sandpaper} (reported: @uschille, https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar, #121)
+
+
 # pegboard 0.5.2 (2023-04-05)
 
 BUG FIX
@@ -39,7 +50,7 @@ NEW FEATURES
 
 * `$validate_links()` now checks if the URL protocol in an external link matches
   a known list of protocols. Those that do not match (e.g. `javascript:` and
-  `bitcoin:`) will be flagged. (@zkavmar #109)
+  `bitcoin:`) will be flagged. (@zkamvar #109)
 
 BUG FIX
 -------

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -78,7 +78,9 @@ Episode <- R6::R6Class("Episode",
         }
       }
 
-      if (fix_links) fix_links(lsn$body)
+      if (fix_links) {
+        lsn$body <- fix_links(lsn$body)
+      }
 
       # Initialize the object
       self$path <- path

--- a/R/fix_links.R
+++ b/R/fix_links.R
@@ -209,7 +209,24 @@ fix_broken_link_too <- function(nodes) {
   }
 
   xml2::xml_remove(nodes)
+  add_sibling_sourcepos(new_node)
   new_node
+}
+
+# When we create a new node for a link,
+add_sibling_sourcepos <- function(node) {
+  if (!is.na(xml2::xml_attr(node, "sourcepos"))) {
+    # bail early if we have a source position
+    return(invisible(node))
+  }
+  # find the sibling node right before this node
+  preceding <- xml2::xml_find_first(node, ".//preceding-sibling::*[1]")
+  sourcepos <- xml2::xml_attr(preceding, "sourcepos")
+  if (is.na(sourcepos)) {
+    # add the parent source position if we can't find a sibling
+    sourcepos <- xml2::xml_attr(xml2::xml_parent(node), "sourcepos")
+  }
+  xml2::xml_set_attr(node, "sourcepos", sourcepos)
 }
 
 resolve_end_node <- function(node) {

--- a/R/make_pandoc_alt.R
+++ b/R/make_pandoc_alt.R
@@ -14,15 +14,16 @@ make_pandoc_alt <- function(images) {
   # ![ ](img) // decorative
   has_alt <- alt != ""
   no_url <- !grepl("https?[:][/][/]", alt)
-  has_attrs <- xml2::xml_find_lgl(images, 
-    "boolean(self::*[following-sibling::*[1][starts-with(text(), '{')]])")
+  attr_XPath <- "self::*[following-sibling::*[starts-with(text(), '{')]][1]" 
+  has_attrs <- xml2::xml_find_lgl(images, glue::glue("boolean({attr_XPath})"))
 
   # Add alt text to images that already has attributes
   append_these <- has_attrs & has_alt & no_url
   to_append <- alt[append_these]
   if (length(to_append)) {
     imgs  <- images[append_these]
-    nodes <- xml2::xml_find_first(imgs, "self::*/following-sibling::*[1]")
+    XPath <- ".//self::*/following-sibling::*[starts-with(text(), '{')][1]"
+    nodes <- xml2::xml_find_first(imgs, XPath)
     txt <- xml2::xml_text(nodes)
     subbed <- purrr::map2_chr(to_append, txt, 
       ~sub("[{][:]? ?", glue::glue("{alt=^shQuote(trimws(.x))$ ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -190,6 +190,18 @@ xml_new_paragraph <- function(text = "", ns, tag = TRUE) {
   xml2::xml_child(pgp, 1)
 }
 
+# stolen from {tinkr}
+make_text_nodes <- function(txt) {
+  # We are hijacking commonmark here to produce an XML markdown document with
+  # a single element: {paste(txt, collapse = ''). This gets passed to glue where
+  # it is expanded into nodes that we can read in via {xml2}, strip the
+  # namespace, and extract all nodes below
+  doc <- glue::glue(commonmark::markdown_xml("{paste(txt, collapse = '')}"))
+  nodes <- xml2::xml_ns_strip(xml2::read_xml(doc))
+  xml2::xml_find_all(nodes, ".//paragraph/text/*")
+}
+
+
 #' Retrieve the setup chunk if it exists, create one and insert it at the head 
 #' of the document if it does not
 #' @param body an xml node

--- a/R/xml_to_md.R
+++ b/R/xml_to_md.R
@@ -2,6 +2,9 @@
 #'
 #' @param body an xml document
 #' @param stylesheet the name of a stylesheet passed to `get_stylesheet`
+#' @param newlines a logical indicating that newlines (aka softbreaks) should
+#'   be inserted between elements (defaults to `FALSE`, meaning that no
+#'   separator will be added between elements).
 #' @return a character vector of length 1
 #' @keywords internal
 #' @examples
@@ -10,14 +13,19 @@
 #' xml2::xml_add_child(cha, xml2::xml_child(sol, 1), .where =  1)
 #' xml2::xml_add_child(cha, xml2::xml_child(sol, 2), .where = 2)
 #' cat(pegboard:::xml_to_md(cha))
-xml_to_md <- function(body, stylesheet = "xml2md_roxy.xsl") {
+xml_to_md <- function(body, stylesheet = "xml2md_gfm_kramdown.xsl", newlines = FALSE) {
   stysh <- xml2::read_xml(get_stylesheet(stylesheet))
-  is_fragment <- xml2::xml_name(body) != "document" ||
-    xml2::xml_name(xml2::xml_parent(body)) != ""
+  is_fragment <- !inherits(body, "xml_document")
   if (is_fragment) {
     d <- xml2::read_xml(commonmark::markdown_xml(""))
-    purrr::walk(body, ~xml2::xml_add_child(d, .x))
+    purrr::walk(body, function(x, new){
+      xml2::xml_add_child(d, x)
+      if (new) {
+        xml2::xml_add_child(d, "softbreak")
+      }
+    }, new = newlines)
     body <- d
   } 
+  body <- xml2::read_xml(as.character(body))
   xslt::xml_xslt(body, stysh)
 }

--- a/man/fix_links.Rd
+++ b/man/fix_links.Rd
@@ -163,7 +163,7 @@ e$links  # five links
 e$images # four images
 
 # fix_links() ---------------------------------------------------------------
-asNamespace("pegboard")$fix_links(e$body)
+e$body <- asNamespace("pegboard")$fix_links(e$body)
 e$links  # eight links
 e$images # five images
 
@@ -178,7 +178,7 @@ data.frame(res)
 grepl(helpers["find_links"], res, perl = TRUE)
 
 # text_to_links() -----------------------------------------------------------
-txt <- "Some text [and a link]({{ page.root }}/link.to#thing), 
+txt <- "Some text [and _a link_]({{ page.root }}/link.to#thing), 
 some other text."
 pegboard:::text_to_links(txt, type = "link")
 md <- c(md = "http://commonmark.org/xml/1.0")

--- a/man/xml_to_md.Rd
+++ b/man/xml_to_md.Rd
@@ -4,12 +4,16 @@
 \alias{xml_to_md}
 \title{Convert xml to markdown}
 \usage{
-xml_to_md(body, stylesheet = "xml2md_roxy.xsl")
+xml_to_md(body, stylesheet = "xml2md_gfm_kramdown.xsl", newlines = FALSE)
 }
 \arguments{
 \item{body}{an xml document}
 
 \item{stylesheet}{the name of a stylesheet passed to \code{get_stylesheet}}
+
+\item{newlines}{a logical indicating that newlines (aka softbreaks) should
+be inserted between elements (defaults to \code{FALSE}, meaning that no
+separator will be added between elements).}
 }
 \value{
 a character vector of length 1

--- a/tests/testthat/_snaps/Lesson.md
+++ b/tests/testthat/_snaps/Lesson.md
@@ -268,7 +268,7 @@
       ::warning file=_episodes/14-looping-data-sets.md,line=191:: [missing file]: [](../no-workie.svg)
       ::warning file=_episodes/14-looping-data-sets.md,line=195:: [image missing alt-text]: https://carpentries.org/assets/img/TheCarpentries.svg
       ::warning file=_episodes/14-looping-data-sets.md,line=197:: [missing file]: [Non-working image](../no-workie.svg) [image missing alt-text]: ../no-workie.svg
-      ::warning file=_episodes/14-looping-data-sets.md,line=NA:: [image missing alt-text]: { page.root }/no-workie.svg
+      ::warning file=_episodes/14-looping-data-sets.md,line=199:: [image missing alt-text]: { page.root }/no-workie.svg
 
 # Lessons can be validated [ansi]
 
@@ -349,7 +349,7 @@
       ::warning file=_episodes/14-looping-data-sets.md,line=191:: [missing file]: [](../no-workie.svg)
       ::warning file=_episodes/14-looping-data-sets.md,line=195:: [image missing alt-text]: https://carpentries.org/assets/img/TheCarpentries.svg
       ::warning file=_episodes/14-looping-data-sets.md,line=197:: [missing file]: [Non-working image](../no-workie.svg) [image missing alt-text]: ../no-workie.svg
-      ::warning file=_episodes/14-looping-data-sets.md,line=NA:: [image missing alt-text]: { page.root }/no-workie.svg
+      ::warning file=_episodes/14-looping-data-sets.md,line=199:: [image missing alt-text]: { page.root }/no-workie.svg
 
 # Lessons can be validated [unicode]
 
@@ -430,7 +430,7 @@
       ::warning file=_episodes/14-looping-data-sets.md,line=191:: [missing file]: [](../no-workie.svg)
       ::warning file=_episodes/14-looping-data-sets.md,line=195:: [image missing alt-text]: https://carpentries.org/assets/img/TheCarpentries.svg
       ::warning file=_episodes/14-looping-data-sets.md,line=197:: [missing file]: [Non-working image](../no-workie.svg) [image missing alt-text]: ../no-workie.svg
-      ::warning file=_episodes/14-looping-data-sets.md,line=NA:: [image missing alt-text]: { page.root }/no-workie.svg
+      ::warning file=_episodes/14-looping-data-sets.md,line=199:: [image missing alt-text]: { page.root }/no-workie.svg
 
 # Lessons can be validated [fancy]
 
@@ -511,5 +511,5 @@
       ::warning file=_episodes/14-looping-data-sets.md,line=191:: [missing file]: [](../no-workie.svg)
       ::warning file=_episodes/14-looping-data-sets.md,line=195:: [image missing alt-text]: https://carpentries.org/assets/img/TheCarpentries.svg
       ::warning file=_episodes/14-looping-data-sets.md,line=197:: [missing file]: [Non-working image](../no-workie.svg) [image missing alt-text]: ../no-workie.svg
-      ::warning file=_episodes/14-looping-data-sets.md,line=NA:: [image missing alt-text]: { page.root }/no-workie.svg
+      ::warning file=_episodes/14-looping-data-sets.md,line=199:: [image missing alt-text]: { page.root }/no-workie.svg
 

--- a/tests/testthat/_snaps/conversion.md
+++ b/tests/testthat/_snaps/conversion.md
@@ -30,8 +30,8 @@
       
       ![Non-working image with jekyll syntax]({{ page.root }}/no-workie.svg)
       
-      This text includes a [link that isn't parsed correctly by commonmark]({{ page.root }}{% link)
-      index.md %}). The rest of the text should be properly parsed.
+      This text includes a [link that isn't parsed correctly by commonmark]({{ page.root }}{% link index.md %})
+      . The rest of the text should be properly parsed.
       
       {% include links.md %}
       

--- a/tests/testthat/_snaps/fix_sandpaper_links.md
+++ b/tests/testthat/_snaps/fix_sandpaper_links.md
@@ -10,12 +10,12 @@
        [5] "https://docs.python.org/3/library/stdtypes.html#str.split"                             
        [6] "https://carpentries.org/assets/img/TheCarpentries.svg"                                 
        [7] "no-workie.svg"                                                                         
-       [8] "https://carpentries.org/assets/img/TheCarpentries.svg"                                 
-       [9] "no-workie.svg"                                                                         
-      [10] "index.html"                                                                            
-      [11] "https://swcarpentry.github.io/shell-novice"                                            
-      [12] "index.md"                                                                              
-      [13] "no-workie.svg"                                                                         
+       [8] "index.html"                                                                            
+       [9] "https://swcarpentry.github.io/shell-novice"                                            
+      [10] "https://carpentries.org/assets/img/TheCarpentries.svg"                                 
+      [11] "no-workie.svg"                                                                         
+      [12] "no-workie.svg"                                                                         
+      [13] "index.md"                                                                              
 
 # links are replaced in messy example
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -87,7 +87,7 @@
       _episodes/14-looping-data-sets.md:191  [missing file]: [](../no-workie.svg)
       _episodes/14-looping-data-sets.md:195  [image missing alt-text]: https://carpentries.org/assets/img/TheCarpentries.svg
       _episodes/14-looping-data-sets.md:197  [missing file]: [Non-working image](../no-workie.svg) [image missing alt-text]: ../no-workie.svg
-      _episodes/14-looping-data-sets.md:NA  [image missing alt-text]: {{ page.root }}/no-workie.svg
+      _episodes/14-looping-data-sets.md:199  [image missing alt-text]: {{ page.root }}/no-workie.svg
 
 ---
 

--- a/tests/testthat/examples/link-liquid-markdown.md
+++ b/tests/testthat/examples/link-liquid-markdown.md
@@ -3,10 +3,13 @@ title: "Test for markdown content inside liquid links"
 ---
 
 
-[normal liquid link]({{ page.root}}{% link _episodes/test.md %})
 [_markdown formatted_ liquid link]({{ page.root}}{% link _episodes/test.md %})
 [second _markdown formatted_ liquid link]({{ page.root}}{% link _episodes/test.md %})
 [third _markdown formatted_ liquid link]({{ page.root }}/test/)
+
+![third _markdown formatted_ liquid image]({{ page.root }}/test/)
+
+[normal liquid link]({{ page.root}}{% link _episodes/test.md %})
 
 [first _markdown formatted_ relative link](../test/)
 [second _markdown formatted_ relative link](../test/index.html)

--- a/tests/testthat/examples/link-liquid-markdown.md
+++ b/tests/testthat/examples/link-liquid-markdown.md
@@ -1,0 +1,18 @@
+---
+title: "Test for markdown content inside liquid links"
+---
+
+
+[normal liquid link]({{ page.root}}{% link _episodes/test.md %})
+[_markdown formatted_ liquid link]({{ page.root}}{% link _episodes/test.md %})
+[second _markdown formatted_ liquid link]({{ page.root}}{% link _episodes/test.md %})
+[third _markdown formatted_ liquid link]({{ page.root }}/test/)
+
+[first _markdown formatted_ relative link](../test/)
+[second _markdown formatted_ relative link](../test/index.html)
+[third _markdown formatted_ relative link](/lesson/test/index.html)
+
+[_markdown formatted_ liquid link](https://example.com/test/)
+[second _markdown formatted_ liquid link](https://example.com/test/)
+[third _markdown formatted_ liquid link](https://example.com/test/)
+

--- a/tests/testthat/examples/post-image-tag.md
+++ b/tests/testthat/examples/post-image-tag.md
@@ -11,7 +11,8 @@ click the `Add file` button and select `Create new file` from the dropdown.
 
 Next, type some text into `index.md`.
 
-![Create index.md file](../fig/github_add_index.png){: .image-with-shadow width="900px" }
+![Create index.md file](../fig/github_add_index.png)
+{: .image-with-shadow width="900px"}
 
 We are now ready to start adding more content to our website. Let's do some exercises.
 

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -75,9 +75,10 @@ test_that("Episodes with image tags do not error", {
   expect_equal(tab$alt, expected)
   img <- ep$images
   expect_length(img, 3L)
-  post_image <- xml2::xml_find_first(img, ".//self::*/following-sibling::*")
+  attrs <- ".//self::*/following-sibling::md:text"
+  post_image <- xml2::xml_find_first(img, attrs, ep$ns)
   expect_match(xml2::xml_text(post_image), " \\.image-with-shadow ")
-  expect_match(xml2::xml_text(post_image), " width=\"900px\" ")
+  expect_match(xml2::xml_text(post_image), " width=\"900px\"")
 
 })
 

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -30,7 +30,8 @@ test_that("Episodes with markdown formatted liquid links can be processed", {
   llm <- test_path("examples", "link-liquid-markdown.md")
   
   txt <- readLines(llm)
-  res <- pegboard::Episode$new(llm)$use_sandpaper()$show()
+  ep  <- pegboard::Episode$new(llm, fix_liquid = TRUE)
+  res <- ep$use_sandpaper()$show()
   # There should only be one opening bracket per link, resulting in a vector
   # of length two when split on the opening square bracket
   values <- res[startsWith(res, "[")]
@@ -121,7 +122,7 @@ test_that("Episodes can be converted to use sandpaper", {
     xml2::xml_attr(jek_links, "destination"),
     c("{{ page.root }}/index.html", 
       "{{ site.swc_pages }}/shell-novice", 
-      "{{ page.root }}{% link")
+      "{{ page.root }}{% link index.md %}")
   )
   expect_snapshot(cat(e$tail(17), sep = "\n"))
 


### PR DESCRIPTION
This fixes link parsing to take into account links that have markdown inside them.

```markdown
[a _link_ with **markdown**]({{ page.root }}/linkie)
```

This will fix #120


This also updates jekyll image attribute parsing and takes into account attributes that are situated on a separate line as the image:


```markdown
![image alt text](https://placekitten.com/200/200)
{.image-with-shadow}
```

This addresses #119, but does not necessarily fix it because figure attributes on new lines are not allowed (afaict):

``` r
pandoc::pandoc_convert(text = "![a](link)\n{alt='b'}", to = "html")
#> <p><img src="link" alt="a" /> {alt=‘b’}</p>
pandoc::pandoc_convert(text = "![a](link){alt='b'}", to = "html")
#> <figure>
#> <img src="link" alt="b" />
#> <figcaption>a</figcaption>
#> </figure>
```

<sup>Created on 2023-04-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>