### PR TITLE
insert blocks at top of document not after first element

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,10 +3,19 @@
 BUG FIX
 -------
 
-* liquid-formatted links with markdown inside them are now more accurately
-  transitioned to use {sandpaper} (reported: @uschille, https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar, #121)
+* `$move_objectives()` and `$move_questions()` methods no longer place these
+  blocks as the _second_ element in the markdown. This was originally
+  implemented when we thought {dovetail} would be our solution to the lesson 
+  infrastructure (and thus needed a setup chunk before any blocks).
+* liquid-formatted links with markdown inside them are now parsed correctly.
+  This leads lessons to be more accurately transitioned to use {sandpaper}
+  (reported: @uschille,
+  https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar,
+  #121)
 - images with kramdown attributes that are on a new line are now more accurately
-  transitioned to use {sandpaper} (reported: @uschille, https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar, #121)
+  transitioned to use {sandpaper} (reported: @uschille,
+  https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar,
+  #121)
 
 
 # pegboard 0.5.2 (2023-04-05)

--- a/R/move_yaml.R
+++ b/R/move_yaml.R
@@ -1,6 +1,6 @@
 move_yaml <- function(yaml, body, what = "questions", dovetail = TRUE) {
   NS <- xml2::xml_ns(body)[[1]]
-  where <- if (what == "keypoints") length(xml2::xml_children(body)) else 1L
+  where <- if (what == "keypoints") length(xml2::xml_children(body)) else 0L
   if (dovetail) {
     to_insert <- prepare_yaml_packet(yaml, what, dovetail)
     xml2::xml_add_child(body,

--- a/R/move_yaml.R
+++ b/R/move_yaml.R
@@ -1,6 +1,7 @@
 move_yaml <- function(yaml, body, what = "questions", dovetail = TRUE) {
   NS <- xml2::xml_ns(body)[[1]]
-  where <- if (what == "keypoints") length(xml2::xml_children(body)) else 0L
+  where <- as.integer(dovetail)
+  where <- if (what == "keypoints") length(xml2::xml_children(body)) else where
   if (dovetail) {
     to_insert <- prepare_yaml_packet(yaml, what, dovetail)
     xml2::xml_add_child(body,

--- a/tests/testthat/test-conversion.R
+++ b/tests/testthat/test-conversion.R
@@ -376,11 +376,13 @@ test_that("Integration: for markdown sandpaper sites without dovetail", {
     move_objectives()
 
   # The first child is not an RMD chunk
-  expect_equal(xml2::xml_text(xml2::xml_child(e$body)), 
+  expect_equal(xml2::xml_attr(xml2::xml_child(e$body), "label"), 
+    "div-1-objectives"
+  )
+  # first heading is what we expect
+  expect_equal(xml2::xml_text(e$headings[[1]]), 
     "Use a for loop to process files given a list of their names."
   )
-  # NOTE: at the moment, we don't have a non-dovetail solution, but we're getting
-  # there!
   expect_length(e$code, 11)
   # python code chunks exist
   expect_true(any(grepl("python", xml2::xml_attr(e$code, "info"))))


### PR DESCRIPTION
This was causing some issues with the transition, and while it's good for pre-content text, it's often not so great otherwise.

Note: I now understand why it was there in the first place. We originally implemented it for lessons that used [{dovetail}](https://github.com/carpentries/dovetail#readme) as the backend, which needed us to implement a setup chunk at the beginning to load {dovetail}.