### PR TITLE
fix bad test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,12 @@ BUG FIX
   https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar,
   #121)
 
+TESTS
+-----
+
+* A failing test due to the workbench transition was fixed (reported:
+  @zkamvar, #125; fixed: @zkamvar, #127)
+
 
 # pegboard 0.5.2 (2023-04-05)
 

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -295,8 +295,9 @@ test_that("code with embedded div tags are parsed correctly", {
 
 })
 
-test_that("Lessons with Rmd sources can be downloaded", {
+test_that("Styles lessons with Rmd sources can be downloaded", {
 
+  skip("This test was from a pre-workbench lesson infrastructure")
   skip_if_offline()
   skip_on_os("windows")
 


### PR DESCRIPTION
Skip test to fix #125

This was testing a lesson assuming it was from the styles infrastructure, it no
longer is so the test is no longer needed.
