### PR TITLE
tidyize description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,10 +2,20 @@ Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
 Version: 0.5.3
 Authors@R: c(
-    person("Zhian N.", "Kamvar", , "zkamvar@carpentries.org", role = c("aut", "cre"),
+    person(given = "Zhian N.",
+           family = "Kamvar",
+           role = c("aut", "cre"),
+           email = "zkamvar@carpentries.org",
            comment = c(ORCID = "0000-0003-1458-7108")),
-    person("Toby", "Hodges", , "tobyhodges@carpentries.org", role = "ctb")
-  )
+    person(given = "Toby",
+           family = "Hodges",
+           role = c("ctb"),
+           email = "tobyhodges@carpentries.org"),
+    person(given = "Erin", 
+           family = "Becker", 
+           role = c("ctb"),
+           email = "ebecker@carpentries.org"), 
+    person())
 Description: The Carpentries (<https://carpentries.org>) curricula is made
     of of lessons that are hosted as websites. Each lesson represents
     between a half day to two days of instruction and contains several

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,55 +2,51 @@ Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
 Version: 0.5.3
 Authors@R: c(
-    person(given = "Zhian N.",
-           family = "Kamvar",
-           role = c("aut", "cre"),
-           email = "zkamvar@carpentries.org",
+    person("Zhian N.", "Kamvar", , "zkamvar@carpentries.org", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0003-1458-7108")),
-    person(given = "Toby",
-           family = "Hodges",
-           role = c("ctb"),
-           email = "tobyhodges@carpentries.org"),
-    person())
-Description: The Carpentries (<https://carpentries.org>) curricula is made of of
-    lessons that are hosted as websites. Each lesson represents between a half
-    day to two days of instruction and contains several episodes, which are
-    written as 'kramdown'-flavored 'markdown' documents and converted to HTML
-    using the 'Jekyll' static website generator. This package builds on top of
-    the 'tinkr' package; reads in these markdown documents to 'XML' and
-    stores them in R6 classes for convenient exploration and manipulation of
-    sections within episodes.
+    person("Toby", "Hodges", , "tobyhodges@carpentries.org", role = "ctb")
+  )
+Description: The Carpentries (<https://carpentries.org>) curricula is made
+    of of lessons that are hosted as websites. Each lesson represents
+    between a half day to two days of instruction and contains several
+    episodes, which are written as 'kramdown'-flavored 'markdown'
+    documents and converted to HTML using the 'Jekyll' static website
+    generator. This package builds on top of the 'tinkr' package; reads in
+    these markdown documents to 'XML' and stores them in R6 classes for
+    convenient exploration and manipulation of sections within episodes.
 License: MIT + file LICENSE
+URL: https://carpentries.github.io/pegboard
+BugReports: https://github.com/carpentries/pegboard/issues
 Imports:
+    commonmark,
     fs (>= 1.5.0),
+    glue,
+    purrr,
+    R6,
     tinkr (>= 0.2.0),
     xml2,
-    purrr,
-    glue,
-    R6,
     xslt,
-    yaml,
-    commonmark
+    yaml
 Suggests:
+    cli (>= 0.3.4),
+    covr,
+    crayon,
+    dplyr,
     gert (>= 1.0.0),
     here,
-    testthat,
-    withr,
-    covr,
     knitr,
-    rmarkdown,
     magrittr,
-    dplyr,
-    crayon,
-    cli (>= 0.3.4),
-    rlang
+    rlang,
+    rmarkdown,
+    testthat,
+    withr
+VignetteBuilder: 
+    knitr
+Remotes: 
+    ropensci/tinkr
 Additional_repositories: https://carpentries.r-universe.dev/
-Remotes: ropensci/tinkr
 Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-URL: https://carpentries.github.io/pegboard
-BugReports: https://github.com/carpentries/pegboard/issues
-VignetteBuilder: knitr


### PR DESCRIPTION
@zkamvar - I'm working through our Workbench Maintainer Onboarding homework and noticed that the Imports listed in DESCRIPTION aren't alphabetized. This is me using `usethis::use_tidy_description()` to alphabetize and also impose "tidy style" on your DESCIPTION file.  I know this is a trivial formatting thing, but thought it would be an ok first PR for me to get my feet wet. Please feel free to close without merging if this isn't helpful.