### PR TITLE
avoid errors with images embedded in comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,19 +1,22 @@
-# pegboard 0.5.3 (unreleased)
+# pegboard 0.5.3 (2023-07-08)
 
 BUG FIX
 -------
 
-* `$move_objectives()` and `$move_questions()` methods no longer place these
-  blocks as the _second_ element in the markdown. This was originally
-  implemented when we thought {dovetail} would be our solution to the lesson 
-  infrastructure (and thus needed a setup chunk before any blocks).
-* liquid-formatted links with markdown inside them are now parsed correctly.
-  This leads lessons to be more accurately transitioned to use {sandpaper}
-  (reported: @uschille,
+* `$validate_links()` no longer throws an error when there are HTML images
+  embedded in comments (reported: @beastyblacksmith, #130; fixed: @zkamvar,
+  #131)
+* (transition) `$move_objectives()` and `$move_questions()` methods no longer
+  place these blocks as the _second_ element in the markdown. This was
+  originally implemented when we thought {dovetail} would be our solution to
+  the lesson infrastructure (and thus needed a setup chunk before any blocks).
+* (transition) liquid-formatted links with markdown inside them are now parsed
+  correctly. This leads lessons to be more accurately transitioned to use
+  {sandpaper} (reported: @uschille,
   https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar,
   #121)
-- images with kramdown attributes that are on a new line are now more accurately
-  transitioned to use {sandpaper} (reported: @uschille,
+- (transition) images with kramdown attributes that are on a new line are now
+  more accurately transitioned to use {sandpaper} (reported: @uschille,
   https://github.com/carpentries/lesson-transition/issues/46; fixed: @zkamvar,
   #121)
 

--- a/R/get_images.R
+++ b/R/get_images.R
@@ -5,7 +5,33 @@
 #'   [process_images()] to add the alt attribute and extract images from HTML
 #'   blocks. `FALSE` will present the nodes as found by XPath search.
 #' @return an xml_nodelist
+#' @details Markdown users can write images as either markdown or HTML. If they
+#' write images as HTML, then the commonmark XML parser recognises these as
+#' generic "HTML blocks" and they can't be found by just searching for
+#' `.//md:image`. This function searches both `md:html_block` and
+#' `md:html_inline` for image content that it can extract for downstream
+#' analysis.
+#'
 #' @keywords internal
+#' @examples
+#' tmp <- tempfile()
+#' on.exit(unlink(tmp))
+#' txt <- '
+#' ![a kitten](https://placekitten.com/200/200){alt="a pretty kitten"}
+#'
+#' <!-- an html image of a kitten -->
+#' <img src="https://placekitten.com/200/200">
+#'
+#' an inline html image of a kitten <img src="https://placekitten.com/50/50">
+#' '
+#' writeLines(txt, tmp)
+#' ep <- Episode$new(tmp)
+#' ep$show()
+#' # without process = TRUE, images in HTML elements are not converted
+#' ep$get_images() 
+#' # setting process = TRUE will extract the HTML elements for analysis 
+#' # (e.g to detect alt text)
+#' ep$get_images(process = TRUE)
 get_images <- function(yrn, process = TRUE) {
   img    <- ".//md:image"
   hblock <- ".//md:html_block[contains(text(), '<img')]"

--- a/R/get_images.R
+++ b/R/get_images.R
@@ -9,8 +9,10 @@
 get_images <- function(yrn, process = TRUE) {
   img    <- ".//md:image"
   hblock <- ".//md:html_block[contains(text(), '<img')]"
+  # comment blocks should not be included in the image processing. 
+  nocomment <- "[not(starts-with(normalize-space(text()), '<!--'))]"
   hline  <- ".//md:html_inline[starts-with(text(), '<img')]"
-  xpath  <- glue::glue("{img} | {hblock} | {hline}")
+  xpath  <- glue::glue("{img} | {hblock}{nocomment} | {hline}")
   images <- xml2::xml_find_all(yrn$body, xpath, yrn$ns)
   images <- if (process) process_images(images) else images
   images

--- a/man/get_images.Rd
+++ b/man/get_images.Rd
@@ -19,4 +19,32 @@ an xml_nodelist
 \description{
 Get images from an Episode/yarn object
 }
+\details{
+Markdown users can write images as either markdown or HTML. If they
+write images as HTML, then the commonmark XML parser recognises these as
+generic "HTML blocks" and they can't be found by just searching for
+\verb{.//md:image}. This function searches both \code{md:html_block} and
+\code{md:html_inline} for image content that it can extract for downstream
+analysis.
+}
+\examples{
+tmp <- tempfile()
+on.exit(unlink(tmp))
+txt <- '
+![a kitten](https://placekitten.com/200/200){alt="a pretty kitten"}
+
+<!-- an html image of a kitten -->
+<img src="https://placekitten.com/200/200">
+
+an inline html image of a kitten <img src="https://placekitten.com/50/50">
+'
+writeLines(txt, tmp)
+ep <- Episode$new(tmp)
+ep$show()
+# without process = TRUE, images in HTML elements are not converted
+ep$get_images() 
+# setting process = TRUE will extract the HTML elements for analysis 
+# (e.g to detect alt text)
+ep$get_images(process = TRUE)
+}
 \keyword{internal}

--- a/man/pegboard-package.Rd
+++ b/man/pegboard-package.Rd
@@ -24,6 +24,7 @@ Useful links:
 Other contributors:
 \itemize{
   \item Toby Hodges \email{tobyhodges@carpentries.org} [contributor]
+  \item Erin Becker \email{ebecker@carpentries.org} [contributor]
 }
 
 }

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -29,3 +29,55 @@ test_that("markdown images will process alt text appropriately", {
   expect_equal(xml2::xml_attr(images, "alt"), expected_alts)
 })
 
+
+test_that("HTML images in comments do not error", {
+  # see https://github.com/carpentries/pegboard/issues/130
+
+  tmp <- withr::local_tempfile()
+
+  all_comment <- r"{
+  some text and 
+
+  <!-- <img src='whoops.png'> -->
+  }"
+  writeLines(all_comment, tmp)
+  ep <- pegboard::Episode$new(tmp)
+  res <- ep$validate_links(warn = FALSE)
+  expect_null(res)
+})
+
+
+test_that("HTML images surrounded by comments are processed. ", {
+
+  tmp <- withr::local_tempfile()
+
+  some_comment<- r"{
+There is only one HTML image here and it will be processed.
+NOTE: each comment block is parsed as an individual HTML block,
+and the numbers in this example help us understand that fact.
+
+<!-- <img src='whoops.png'> ONE -->
+<!-- <img src='whoops.png'> 
+       <img src='whoops.png'> 
+   TWO
+   -->
+   <!-- <img src='whoops.png'> THREE -->
+  <img src='okay.png'> <!-- <img src='whoops.png'> -->
+
+  <!-- <img src='whoops.png'> FOUR -->
+  }"
+  writeLines(some_comment, tmp)
+  ep <- pegboard::Episode$new(tmp)
+  res <- ep$validate_links(warn = FALSE)
+  expect_equal(nrow(res), 1L)
+  # There are four HTML blocks 
+  blocks <- xml2::xml_find_all(ep$body, ".//md:html_block", ns = ep$ns)
+  expect_length(blocks, 4L)
+  # when we extract the number elements, they are what we expect.
+  expect_equal(gsub("[^A-Z]", "", xml2::xml_text(blocks)), 
+    c("ONE", "TWO", "THREE", "FOUR"))
+
+})
+
+
+

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -51,7 +51,7 @@ test_that("HTML images surrounded by comments are processed. ", {
 
   tmp <- withr::local_tempfile()
 
-  some_comment<- "
+  some_comment <- "
 There is only one HTML image here and it will be processed.
 NOTE: each comment block is parsed as an individual HTML block,
 and the numbers in this example help us understand that fact.

--- a/tests/testthat/test-get_images.R
+++ b/tests/testthat/test-get_images.R
@@ -35,11 +35,11 @@ test_that("HTML images in comments do not error", {
 
   tmp <- withr::local_tempfile()
 
-  all_comment <- r"{
+  all_comment <- "
   some text and 
 
   <!-- <img src='whoops.png'> -->
-  }"
+  "
   writeLines(all_comment, tmp)
   ep <- pegboard::Episode$new(tmp)
   res <- ep$validate_links(warn = FALSE)
@@ -51,7 +51,7 @@ test_that("HTML images surrounded by comments are processed. ", {
 
   tmp <- withr::local_tempfile()
 
-  some_comment<- r"{
+  some_comment<- "
 There is only one HTML image here and it will be processed.
 NOTE: each comment block is parsed as an individual HTML block,
 and the numbers in this example help us understand that fact.
@@ -65,7 +65,7 @@ and the numbers in this example help us understand that fact.
   <img src='okay.png'> <!-- <img src='whoops.png'> -->
 
   <!-- <img src='whoops.png'> FOUR -->
-  }"
+  "
   writeLines(some_comment, tmp)
   ep <- pegboard::Episode$new(tmp)
   res <- ep$validate_links(warn = FALSE)


### PR DESCRIPTION
In this PR, I have 

 - added two tests to reproduce #130 
 - fixed the test with two lines in `get_images()`
 - updated the documentation for `get_images()` with an example
 - updated the NEWS
 
## Testing 

You can test this version of {pegboard} by using the [pull request helpers](https://usethis.r-lib.org/articles/pr-functions.html#review-of-the-pull-request) from the {usethis} package inside your local clone of {pegboard}

```r
# FETCH AND LOAD -----------------------------------------
library("usethis")
library("devtools")
library("testthat")
pr_fetch(131)
load_all()

# reprex from 130 ----------------------------------------
tmp <- withr::local_tempfile()
txt <- r"{
some text and 

<!-- <img src='whoops.png'> -->
}"
writeLines(txt, tmp)

# Test that it's silent with testthat --------------------
expect_silent(pegboard::Episode$new(tmp)$validate_links())
```

When you run the above, you should see no output, which means that you have confirmed that #130 is fixed! **When you are done testing**, you can clean up your workspace by running:

```r
pr_finish()
```

## Background

There was a situation where an HTML image embedded in an HTML comment would produce an error like this using the `$validate_links()` method:

```
Error in `purrr::map()`:
ℹ In index: 10.
ℹ With name: 6_Control_flow.md.
Caused by error in `purrr::map()`:
ℹ In index: 1.
Caused by error in `UseMethod()`:
! nicht anwendbare Methode für 'xml_find_all' auf Objekt der Klasse "xml_document" angewendet
```

This is happening because something like this:

```
<!-- <img src='hi.png'> -->
```

is detected as an images within an HTML block on this line in `get_images()`:

https://github.com/carpentries/pegboard/blob/dbc40280b29c85d25654735767c682e2f64f28a5/R/get_images.R#L11

This PR fixes that by explicitly adding the XPath predicate `[not(starts-with(normalize-space(text()), '<!--'))]` to the statement, which will prevent any HTML starting with `<!--` to pass through. 

This will fix #130 