### PR TITLE
add spoiler to list of accepted fenced div classes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: pegboard
 Title: Explore and Manipulate Markdown Curricula from the Carpentries
-Version: 0.6.0
+Version: 0.6.1
 Authors@R: c(
     person(given = "Zhian N.",
            family = "Kamvar",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,12 @@
+# pegboard 0.6.1 (2023-08-31)
+
+NEW FEATURES
+------------
+
+* `$validate_divs()` method now recognises the `spoiler` class of fenced divs
+  which allow optional/expandable items that are not automatically shown to the
+  learner (implemented: @tobyhodges, #134)
+
 # pegboard 0.6.0 (2023-08-29)
 
 NEW FEATURES

--- a/R/validate_divs.R
+++ b/R/validate_divs.R
@@ -1,5 +1,5 @@
 #' Validate Callout Blocks for sandpaper episodes
-#' 
+#'
 #'
 #' The Carpentries Workbench uses [pandoc fenced
 #' divs](https://pandoc.org/MANUAL.html#extension-fenced_divs) to create special
@@ -9,9 +9,9 @@
 #'
 #' ```markdown
 #' ::: callout
-#' 
+#'
 #' ### Hello!
-#' 
+#'
 #' This is a callout block
 #'
 #' :::
@@ -35,7 +35,7 @@
 #'  - checklist
 #'  - testimonial
 #'
-#' Any other div names will produce structure in the resulting DOM, but they 
+#' Any other div names will produce structure in the resulting DOM, but they
 #' will not have any special visual styling.
 #'
 #' @inheritParams validate_links
@@ -74,7 +74,8 @@ KNOWN_DIVS <- c(
   "discussion",
   "testimonial",
   "keypoints",
-  "instructor"
+  "instructor",
+  "spoiler"
 )
 
 #' @rdname validate_divs

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -58,7 +58,7 @@
     Message <pbMessage>
       ! There were errors in 1/5 fenced divs
       
-      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       validation-divs.md:26  [unknown div] unknown
 
@@ -494,7 +494,7 @@
       dv$validate_divs()
     Message <cliMessage>
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -504,7 +504,7 @@
       dv$validate_divs()
     Message <cliMessage>
       [33m![39m There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -514,7 +514,7 @@
       dv$validate_divs()
     Message <cliMessage>
       ! There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -524,7 +524,7 @@
       dv$validate_divs()
     Message <cliMessage>
       [33m![39m There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -639,7 +639,7 @@
       dv$validate_divs()
     Message <cliMessage>
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
       
       ::warning file=validation-divs.md,line=26:: [unknown div] unknown
 


### PR DESCRIPTION
Related to https://github.com/carpentries/sandpaper/pull/502 and https://github.com/carpentries/varnish/pull/92.

Tells pegboard to accept fenced divs of class `spoiler`.