### PR TITLE
Add support for tabs / tabset panels

### DIFF
--- a/R/validate_divs.R
+++ b/R/validate_divs.R
@@ -35,6 +35,7 @@
 #'  - checklist
 #'  - testimonial
 #'  - tab (can only contain text, images, and code blocks)
+#'  - group-tab (can only contain text, images, and code blocks)
 #'
 #' Any other div names will produce structure in the resulting DOM, but they
 #' will not have any special visual styling.
@@ -77,7 +78,8 @@ KNOWN_DIVS <- c(
   "keypoints",
   "instructor",
   "spoiler",
-  "tab"
+  "tab",
+  "group-tab"
 )
 
 #' @rdname validate_divs

--- a/R/validate_divs.R
+++ b/R/validate_divs.R
@@ -34,6 +34,7 @@
 #'  - discussion
 #'  - checklist
 #'  - testimonial
+#'  - tab (can only contain text, images, and code blocks)
 #'
 #' Any other div names will produce structure in the resulting DOM, but they
 #' will not have any special visual styling.
@@ -75,7 +76,8 @@ KNOWN_DIVS <- c(
   "testimonial",
   "keypoints",
   "instructor",
-  "spoiler"
+  "spoiler",
+  "tab"
 )
 
 #' @rdname validate_divs

--- a/man/validate_divs.Rd
+++ b/man/validate_divs.Rd
@@ -74,6 +74,7 @@ The following fenced divs can occur in the lesson, but are not required:
 \item discussion
 \item checklist
 \item testimonial
+\item tab (can only contain text, images, and code blocks)
 }
 
 Any other div names will produce structure in the resulting DOM, but they

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -58,7 +58,7 @@
     Message
       ! There were errors in 1/5 fenced divs
       
-      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       validation-divs.md:26  [unknown div] unknown
 
@@ -494,7 +494,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -504,7 +504,7 @@
       dv$validate_divs()
     Message
       [33m![39m There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -514,7 +514,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -524,7 +524,7 @@
       dv$validate_divs()
     Message
       [33m![39m There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -639,7 +639,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab, group-tab
       
       ::warning file=validation-divs.md,line=26:: [unknown div] unknown
 

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -58,7 +58,7 @@
     Message
       ! There were errors in 1/5 fenced divs
       
-      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      - The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       validation-divs.md:26  [unknown div] unknown
 
@@ -494,7 +494,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -504,7 +504,7 @@
       dv$validate_divs()
     Message
       [33m![39m There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -514,7 +514,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -524,7 +524,7 @@
       dv$validate_divs()
     Message
       [33m![39m There were errors in 1/5 fenced divs
-      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      ◌ The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       validation-divs.md:26 [unknown div] unknown
 
@@ -639,7 +639,7 @@
       dv$validate_divs()
     Message
       ! There were errors in 1/5 fenced divs
-      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler
+      ( ) The Carpentries Workbench knows the following div types callout, objectives, questions, challenge, prereq, checklist, solution, hint, discussion, testimonial, keypoints, instructor, spoiler, tab
       
       ::warning file=validation-divs.md,line=26:: [unknown div] unknown
 


### PR DESCRIPTION
Linked to https://github.com/carpentries/varnish/issues/32 this small change adds the '**tab**' and '**group-tab**' admonitions/panels to the Workbench's **KNOWN_DIVS** so that errors aren't thrown when you build a lesson using these admonitions.
