### PR TITLE
Remove trailing comma in glue::glue()

### DIFF
--- a/R/fix_links.R
+++ b/R/fix_links.R
@@ -117,7 +117,7 @@ make_link_patterns <- function(ns = "md:") {
   predicate <- gsb("(<ctext('({{')> and <ctext('}}')>)")
   asis_nodes <- "text[@asis][text()=']']"
   destination <- glue::glue(
-    ".//{ns}{asis_nodes}/following-sibling::{ns}text[{predicate}]",
+    ".//{ns}{asis_nodes}/following-sibling::{ns}text[{predicate}]"
   )
   return(destination)
 }


### PR DESCRIPTION
This trailing comma has no functional role and seems to be at the origin of #149, as reported in https://github.com/tidyverse/glue/issues/320.

Fixes #149.