### PR TITLE
Change yaml to frontmatter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -67,7 +67,7 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    ropensci/tinkr
+    ropensci/tinkr@toml
 Additional_repositories: https://carpentries.r-universe.dev/
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/Episode.R
+++ b/R/Episode.R
@@ -103,7 +103,7 @@ Episode <- R6::R6Class("Episode",
 
       # Initialize the object
       self$path <- path
-      self$yaml <- ep$yaml
+      self$frontmatter <- ep$frontmatter
       self$body <- ep$body
       self$ns   <- ep$ns
       # if the parents are missing, this walk will do nothing
@@ -208,7 +208,7 @@ Episode <- R6::R6Class("Episode",
     #' @description
     #' Extract the yaml metadata from the episode
     get_yaml = function() {
-      yaml::yaml.load(self$yaml)
+      yaml::yaml.load(self$frontmatter)
     },
     #' @description
     #' Ammend or add a setup code block to use `{dovetail}`
@@ -270,7 +270,7 @@ Episode <- R6::R6Class("Episode",
       suppressWarnings(this_yaml <- self$get_yaml())
       this_yaml[["root"]] <- NULL
       this_yaml[["layout"]] <- NULL
-      self$yaml <- c("---", strsplit(yaml::as.yaml(this_yaml), "\n")[[1]], "---")
+      self$frontmatter <- c("---", strsplit(yaml::as.yaml(this_yaml), "\n")[[1]], "---")
 
       type <- if (rmd) 'use_sandpaper_rmd' else 'use_sandpaper_md'
       private$mutations[type] <- TRUE
@@ -448,7 +448,7 @@ Episode <- R6::R6Class("Episode",
       code <- cp$code
       code <- code[xml2::xml_attr(code, "purl") %in% "TRUE"]
       isolate_elements(cp$body, challenges, code)
-      cp$yaml <- c()
+      cp$frontmatter <- c()
       res <- tinkr::to_md(cp, path = path, stylesheet_path = get_stylesheet())
       if (is.null(path)) {
         invisible(res)
@@ -582,7 +582,7 @@ Episode <- R6::R6Class("Episode",
     validate_headings = function(verbose = TRUE, warn = TRUE) {
       out <- validate_headings(self$headings, 
         self$get_yaml()$title, 
-        offset = length(self$yaml))
+        offset = length(self$frontmatter))
       if (is.null(out)) {
         return(out)
       }
@@ -772,7 +772,7 @@ Episode <- R6::R6Class("Episode",
     clear_yaml_item = function(what) {
       yml <- self$get_yaml()
       yml[[what]] <- NULL
-      self$yaml <- c("---", strsplit(yaml::as.yaml(yml), "\n")[[1]], "---")
+      self$frontmatter <- c("---", strsplit(yaml::as.yaml(yml), "\n")[[1]], "---")
     },
     record_problem = function(x) {
       private$problems <- c(private$problems, x)

--- a/R/div.R
+++ b/R/div.R
@@ -194,7 +194,7 @@ find_between_tags <- function(tag, body, ns = "pb", find = "dtag[@label='{tag}']
 label_div_tags <- function(body) {
   if (!inherits(body, "xml_document")) {
     path <- body$path
-    yaml <- length(body$yaml)
+    yaml <- length(body$frontmatter)
     body <- body$body
   } else {
     path <- NULL

--- a/R/make_div_table.R
+++ b/R/make_div_table.R
@@ -7,7 +7,7 @@
 #'  - pb_label: the label of the div
 #'  - line: the line number of the div label
 make_div_table <- function(yrn) {
-  yml_lines <- length(yrn$yaml)
+  yml_lines <- length(yrn$frontmatter)
   these_divs <- yrn$label_divs()$get_divs()
   labels <- names(these_divs)
   path <- fs::path_rel(yrn$path, yrn$lesson)

--- a/R/make_heading_table.R
+++ b/R/make_heading_table.R
@@ -13,7 +13,7 @@
 #' @examples
 #' path <- file.path(lesson_fragment(), "_episodes", "14-looping-data-sets.md")
 #' loop <- Episode$new(path)
-#' pegboard:::make_heading_table(loop$headings, offset = length(loop$yaml))
+#' pegboard:::make_heading_table(loop$headings, offset = length(loop$frontmatter))
 make_heading_table <- function(headings, offset = 5L) {
   data.frame(
     heading = xml2::xml_text(headings),

--- a/R/make_link_table.R
+++ b/R/make_link_table.R
@@ -26,7 +26,7 @@
 #' make_link_table(Episode$new(loop))
 make_link_table <- function(yrn) {
 
-  yml_lines <- length(yrn$yaml)
+  yml_lines <- length(yrn$frontmatter)
   # Combining nodesets forces these to be lists, meaning that we have to use
   # mappers here.
   limg      <- c(yrn$links, yrn$get_images(process = TRUE))

--- a/R/validate_headings.R
+++ b/R/validate_headings.R
@@ -27,7 +27,7 @@
 #' # Our headings validators run a series of tests on headings and return a data
 #' # frame with information about the headings along with the results of the
 #' # tests
-#' v <- pegboard:::validate_headings(e$headings, e$get_yaml()$title, length(e$yaml))
+#' v <- pegboard:::validate_headings(e$headings, e$get_yaml()$title, length(e$frontmatter))
 #' names(v)
 #' v$results
 #' v$results$path <- fs::path_rel(e$path, e$lesson)

--- a/tests/testthat/test-Episode.R
+++ b/tests/testthat/test-Episode.R
@@ -272,9 +272,9 @@ test_that("isolate_blocks() method works as expected", {
   expect_equal(f[length(f) - 1], "> {: .error}")
 
   # The first thing in the episode is a block quote
-  expect_true(grepl("^>", f[length(e$yaml) + 2]))
+  expect_true(grepl("^>", f[length(e$frontmatter) + 2]))
   # There are only 50 lines beyond the yaml
-  expect_equal(length(f[-seq(length(e$yaml))]), 50)
+  expect_equal(length(f[-seq(length(e$frontmatter))]), 50)
 
 })
 

--- a/tests/testthat/test-get_lesson.R
+++ b/tests/testthat/test-get_lesson.R
@@ -48,6 +48,10 @@ test_that("lessons can be read from local files", {
 test_that("lessons can be downloaded", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
   expect_length(fs::dir_ls(d), 0)
   lex <- get_lesson("carpentries/lesson-example", path = d)
@@ -74,6 +78,11 @@ test_that("lessons can be downloaded", {
 test_that("lessons are accessed without re-downloading", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   # The lesson already exists in the directory
@@ -104,6 +113,10 @@ test_that("lessons are accessed without re-downloading", {
 
 test_that("overwriting is possible", {
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   expect_length(fs::dir_ls(d), 1)
@@ -133,6 +146,10 @@ test_that("overwriting is possible", {
 test_that("Lesson flags will be passed down", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   # The lesson already exists in the directory
@@ -162,6 +179,10 @@ test_that("Lesson flags will be passed down", {
 test_that("Lesson methods work as expected", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   # The lesson already exists in the directory
@@ -285,6 +306,10 @@ test_that("Lesson methods work as expected", {
 test_that("code with embedded div tags are parsed correctly", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   suppressMessages(lex <- get_lesson("carpentries/lesson-example"))
@@ -299,6 +324,10 @@ test_that("Styles lessons with Rmd sources can be downloaded", {
 
   skip("This test was from a pre-workbench lesson infrastructure")
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   expect_false(fs::dir_exists(fs::path(d, "swcarpentry--r-novice-gapminder")))
@@ -317,6 +346,10 @@ test_that("Styles lessons with Rmd sources can be downloaded", {
 test_that("Non-lessons will be downloaded but rejected", {
 
   skip_if_offline()
+  skip_if(interactive())
+  skip_if(isFALSE(as.logical(Sys.getenv("CI", unset = "false"))), 
+    message = "skipped locally to avoid SSL hangups"
+  )
   skip_on_os("windows")
 
   expect_error(


### PR DESCRIPTION
This is in preparation for https://github.com/ropensci/tinkr/pull/127

> [!IMPORTANT]
> When https://github.com/ropensci/tinkr/pull/127 is merged, remove the @toml tag from the ropensci/tinkr in the DESCRIPTION and merge this in.

I am going on vacation tomorrow and will try to release the new tinkr to CRAN when I get back. When that happens, I strongly recommend pinning the carpentries r-universe version to the release. 